### PR TITLE
[Security&Privacy] Skip uninstalled apps

### DIFF
--- a/plugins/security-privacy/trust-store-model.cpp
+++ b/plugins/security-privacy/trust-store-model.cpp
@@ -246,7 +246,12 @@ void TrustStoreModelPrivate::update()
         }
     }
 
-    applications = appMap.values();
+    applications.clear();
+    for (auto i = appMap.constBegin(); i != appMap.constEnd(); i++) {
+        const Application &app = i.value();
+        if (app.displayName.isEmpty()) continue;
+        applications.append(app);
+    }
     updateGrantedCount();
 
     q->endResetModel();

--- a/tests/plugins/security-privacy/CMakeLists.txt
+++ b/tests/plugins/security-privacy/CMakeLists.txt
@@ -1,6 +1,7 @@
 # set(XVFB_CMD xvfb-run -a -s "-screen 0 640x480x24")
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ../../../plugins/security-privacy ${GLIB_INCLUDE_DIRS})
 add_definitions(-DTESTS)
+add_definitions(-DDATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
 
 add_executable(tst-trust-store-model
     tst_trust_store_model.cpp

--- a/tests/plugins/security-privacy/data/applications/Calendar.desktop
+++ b/tests/plugins/security-privacy/data/applications/Calendar.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Calendar
+Exec=my-calendar
+Type=Application
+Icon=calendar

--- a/tests/plugins/security-privacy/data/applications/Gallery.desktop
+++ b/tests/plugins/security-privacy/data/applications/Gallery.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Gallery App
+Exec=my-gallery
+Type=Application
+Icon=gallery

--- a/tests/plugins/security-privacy/data/applications/MyApp.desktop
+++ b/tests/plugins/security-privacy/data/applications/MyApp.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=My beautiful app
+Exec=my-app
+Type=Application
+Icon=something

--- a/tests/plugins/security-privacy/tst_trust_store_model.cpp
+++ b/tests/plugins/security-privacy/tst_trust_store_model.cpp
@@ -241,6 +241,8 @@ void TrustStoreModelTest::init()
 {
     m_store = std::shared_ptr<mock::Store>(new mock::Store);
     mock::Store::setInstance(m_store);
+
+    qputenv("XDG_DATA_HOME", DATA_DIR);
 }
 
 void TrustStoreModelTest::cleanup()
@@ -285,6 +287,12 @@ void TrustStoreModelTest::testList_data()
         (QList<bool>() << true << false << true << false) <<
         (QStringList() << "Calendar" << "Gallery" << "MyApp") <<
         (QList<bool>() << false << false << true);
+
+    QTest::newRow("Invalid app") <<
+        (QStringList() << "Calendar" << "SuperTool" << "MyApp") <<
+        (QList<bool>() << true << false << true) <<
+        (QStringList() << "Calendar" << "MyApp") <<
+        (QList<bool>() << true << true);
 }
 
 void TrustStoreModelTest::testList()


### PR DESCRIPTION
This is a workaround for
https://github.com/ubports/ubuntu-touch/issues/385:
when building the list of app permissions, skip those apps for which a
display name cannot be resolved (meaning that they have most likely been
deleted).

This is only a workaround: the application records in the trust-store
should actually be removed, once an application gets uninstalled.