### PR TITLE
[system-image] Rename system image rootfs part

### DIFF
--- a/plugins/about/Version.qml
+++ b/plugins/about/Version.qml
@@ -64,10 +64,10 @@ ItemPage {
             }
 
             SingleValueStacked {
-                objectName: "ubuntuVersionBuildNumberItem"
-                text: i18n.tr("Ubuntu Image part")
-                value: SystemImage.currentUbuntuBuildNumber
-                visible: SystemImage.currentUbuntuBuildNumber
+                objectName: "ubportsVersionBuildNumberItem"
+                text: i18n.tr("UBports Image part")
+                value: SystemImage.currentUbportsBuildNumber
+                visible: SystemImage.currentUbportsBuildNumber
             }
 
             SingleValueStacked {
@@ -100,4 +100,3 @@ ItemPage {
         }
     }
 }
-

--- a/src/systemimage.cpp
+++ b/src/systemimage.cpp
@@ -312,9 +312,9 @@ int QSystemImage::currentBuildNumber() const
     return m_currentBuildNumber;
 }
 
-QString QSystemImage::currentUbuntuBuildNumber() const
+QString QSystemImage::currentUbportsBuildNumber() const
 {
-    QString val = m_detailedVersion.value("ubuntu").toString();
+    QString val = m_detailedVersion.value("ubports").toString();
     return val.isEmpty() ? SystemSettings::_("Unavailable") : val;
 }
 
@@ -441,7 +441,7 @@ void QSystemImage::setDetailedVersionDetails(const QVariantMap &detailedVersionD
         Q_EMIT detailedVersionDetailsChanged();
 
         // These properties are read from m_detailedVersion, so notify.
-        Q_EMIT currentUbuntuBuildNumberChanged();
+        Q_EMIT currentUbportsBuildNumberChanged();
         Q_EMIT currentDeviceBuildNumberChanged();
         Q_EMIT currentCustomBuildNumberChanged();
 

--- a/src/systemimage.h
+++ b/src/systemimage.h
@@ -45,8 +45,8 @@ class QSystemImage : public QObject
                NOTIFY currentBuildNumberChanged)
     Q_PROPERTY(int targetBuildNumber READ targetBuildNumber
                NOTIFY targetBuildNumberChanged)
-    Q_PROPERTY(QString currentUbuntuBuildNumber READ currentUbuntuBuildNumber
-               NOTIFY currentUbuntuBuildNumberChanged)
+    Q_PROPERTY(QString currentUbportsBuildNumber READ currentUbportsBuildNumber
+               NOTIFY currentUbportsBuildNumberChanged)
     Q_PROPERTY(QString currentDeviceBuildNumber READ currentDeviceBuildNumber
                NOTIFY currentDeviceBuildNumberChanged)
     Q_PROPERTY(QString currentCustomBuildNumber READ currentCustomBuildNumber
@@ -79,7 +79,7 @@ public:
 
     QString deviceName() const;
     QString channelName() const;
-    QString currentUbuntuBuildNumber() const;
+    QString currentUbportsBuildNumber() const;
     QString currentDeviceBuildNumber() const;
     QString currentCustomBuildNumber() const;
     QVariantMap detailedVersionDetails() const;
@@ -115,7 +115,7 @@ Q_SIGNALS:
     void currentBuildNumberChanged();
     void deviceNameChanged();
     void channelNameChanged();
-    void currentUbuntuBuildNumberChanged();
+    void currentUbportsBuildNumberChanged();
     void currentDeviceBuildNumberChanged();
     void currentCustomBuildNumberChanged();
     void targetBuildNumberChanged();

--- a/tests/tst_systemimage.cpp
+++ b/tests/tst_systemimage.cpp
@@ -37,7 +37,7 @@ private Q_SLOTS:
         parameters["build_number"] = 10;
         parameters["target_build_number"] = 42;
         parameters["version_detail"] =
-            "foo=bar,tag=OTA-100,ubuntu=101,device=102,custom=103";
+            "foo=bar,tag=OTA-100,ubports=101,device=102,custom=103";
 
         m_siMock = new FakeSystemImageDbus(parameters);
         m_dbus = new QDBusConnection(m_siMock->dbus());
@@ -167,7 +167,7 @@ private Q_SLOTS:
     }
     void testBuildNumbers()
     {
-        QCOMPARE(m_systemImage->currentUbuntuBuildNumber(), QString("101"));
+        QCOMPARE(m_systemImage->currentUbportsBuildNumber(), QString("101"));
         QCOMPARE(m_systemImage->currentDeviceBuildNumber(), QString("102"));
         QCOMPARE(m_systemImage->currentCustomBuildNumber(), QString("103"));
     }


### PR DESCRIPTION
Our system image rootfs part is called ubports not ubuntu, this is done
from the system-image-server and is just there to display the version of
the rootfs and when it's built. This cannot be changed. As you see right
now it says unavailable this is fixes that.