### PR TITLE
Disable firmware update pending more testing

### DIFF
--- a/plugins/system-update/UpdateSettings.qml
+++ b/plugins/system-update/UpdateSettings.qml
@@ -76,12 +76,13 @@ ItemPage {
                 }
                 onClicked: pageStack.addPageToNextColumn(updatePage, Qt.resolvedUrl("ChannelSettings.qml"))
             }
-            SettingsListItems.SingleValueProgression {
-                objectName: "firmwareUpdate"
-                text: i18n.tr("Firmware update")
-                visible: SystemImage.supportsFirmwareUpdate()
-                onClicked: pageStack.addPageToNextColumn(updatePage, Qt.resolvedUrl("FirmwareUpdate.qml"))
-            }
+            // Disabled pending further testing
+            // SettingsListItems.SingleValueProgression {
+            //     objectName: "firmwareUpdate"
+            //     text: i18n.tr("Firmware update")
+            //     visible: SystemImage.supportsFirmwareUpdate()
+            //     onClicked: pageStack.addPageToNextColumn(updatePage, Qt.resolvedUrl("FirmwareUpdate.qml"))
+            // }
             SettingsListItems.SingleValueProgression {
                 objectName: "appReinstall"
                 text: i18n.tr("Reinstall all apps")


### PR DESCRIPTION
This PR removes the firmware update page from navigation in system-settings. We'll add it back after OTA-4.

Test with ubports/unity8#66