### PR TITLE
Click updater was using the wrong domain

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ubuntu-system-settings (0.4.2~0ubports2) xenial; urgency=medium
+
+  * Fix click updater not using open-store.io API
+
+ -- Dalton Durst <dalton@ubports.com>  Fri, 28 Sep 2018 13:04:00 -0500
+
 ubuntu-system-settings (0.4.2~0ubports1) xenial; urgency=medium
 
   * debian/changelog: New versioning scheme

--- a/plugins/system-update/helpers.cpp
+++ b/plugins/system-update/helpers.cpp
@@ -99,7 +99,7 @@ QString Helpers::getSystemCodename()
 QString Helpers::clickMetadataUrl()
 {
     QString url = QStringLiteral(
-        "https://open.uappexplorer.com/api/v2/apps"
+        "https://open-store.io/api/v2/apps"
     );
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     return environment.value("URL_APPS", url);
@@ -108,7 +108,7 @@ QString Helpers::clickMetadataUrl()
 QString Helpers::clickRevisionUrl()
 {
     QString url = QStringLiteral(
-        "https://open.uappexplorer.com/api/v2/apps/revision"
+        "https://open-store.io/api/v2/apps/revision"
     );
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     return environment.value("URL_REVISION", url);


### PR DESCRIPTION
After the redirect of https://open.uappexplorer.com to https://open-store.io, the click updater in system-settings wasn't able to retrieve a list of app updates. This fixes that problem.