### PR TITLE
Rejigger ClickAppNotifications page

### DIFF
--- a/plugins/notifications/ClickAppNotifications.qml
+++ b/plugins/notifications/ClickAppNotifications.qml
@@ -21,13 +21,16 @@ import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.Notifications 1.0
 import SystemSettings 1.0
 
-ItemPage {
+Page {
     id: appNotificationsPage
 
     property var entry
     property int entryIndex
 
-    title: entry ? entry.displayName : ""
+    header: PageHeader {
+        id: pageHeader
+        title: entry ? entry.displayName : ""
+    }
 
     function disableNotificationsWhenAllUnchecked() {
         if (!entry) {
@@ -42,124 +45,143 @@ ItemPage {
 
     Component.onDestruction: disableNotificationsWhenAllUnchecked()
 
-    Column {
-        id: notificationsColumn
+    Flickable {
+        id: clickAppNotificationsFlickable
+        flickableDirection: Flickable.VerticalFlick
 
-        anchors.fill: parent
+        anchors {
+            top: pageHeader.bottom
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
 
-        ListItem {
-            height: enableNotificationsLayout.height + (divider.visible ? divider.height : 0)
-            ListItemLayout {
-                id: enableNotificationsLayout
-                title.text: i18n.tr("Notifications")
-                Switch {
-                    id: enableNotificationsSwitch
-                    objectName: "enableNotificationsSwitch"
-                    SlotsLayout.position: SlotsLayout.Trailing
-                    checked: entry ? entry.enableNotifications : false
+        Column {
+            id: notificationsColumn
 
-                    onCheckedChanged: {
-                        ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.EnableNotifications,
-                                                                appNotificationsPage.entryIndex,
-                                                                checked)
+            anchors.fill: parent
+
+            ListItem {
+                height: enableNotificationsLayout.height + (divider.visible ? divider.height : 0)
+                ListItemLayout {
+                    id: enableNotificationsLayout
+                    title.text: i18n.tr("Notifications")
+                    Switch {
+                        id: enableNotificationsSwitch
+                        objectName: "enableNotificationsSwitch"
+                        SlotsLayout.position: SlotsLayout.Trailing
+                        checked: entry ? entry.enableNotifications : false
+
+                        onCheckedChanged: {
+                            ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.EnableNotifications,
+                                                                    appNotificationsPage.entryIndex,
+                                                                    checked)
+                        }
+                    }
+                }
+            }
+
+            ListItem {
+                visible: entry ? entry.enableNotifications : false
+                ListItemLayout {
+                    title.text: i18n.tr("Let this app alert me using:")
+                    title.color: theme.palette.normal.backgroundSecondaryText
+                }
+            }
+
+            ListItem {
+                height: soundsLayout.height + (divider.visible ? divider.height : 0)
+                visible: entry ? entry.enableNotifications : false
+                ListItemLayout {
+                    id: soundsLayout
+                    title.text: i18n.tr("Sounds")
+                    CheckBox {
+                        id: soundsChecked
+                        objectName: "soundsChecked"
+                        SlotsLayout.position: SlotsLayout.Leading
+                        enabled: entry ? entry.enableNotifications : false
+                        checked: entry ? entry.soundsNotify : false
+
+                        onCheckedChanged: {
+                            ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.SoundsNotify,
+                                                                    appNotificationsPage.entryIndex,
+                                                                    checked)
+                            disableNotificationsWhenAllUnchecked()
+                        }
+                    }
+                }
+            }
+
+            ListItem {
+                height: vibrationsLayout.height + (divider.visible ? divider.height : 0)
+                visible: entry ? entry.enableNotifications : false
+                ListItemLayout {
+                    id: vibrationsLayout
+                    title.text: i18n.tr("Vibrations")
+                    CheckBox {
+                        id: vibrationsChecked
+                        objectName: "vibrationsChecked"
+                        SlotsLayout.position: SlotsLayout.Leading
+                        enabled: entry ? entry.enableNotifications : false
+                        checked: entry ? entry.vibrationsNotify : false
+
+                        onCheckedChanged: {
+                            ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.VibrationsNotify,
+                                                                    appNotificationsPage.entryIndex,
+                                                                    checked)
+                            disableNotificationsWhenAllUnchecked()
+                        }
+                    }
+                }
+            }
+
+            ListItem {
+                height: bubblesLayout.height + (divider.visible ? divider.height : 0)
+                visible: entry ? entry.enableNotifications : false
+                ListItemLayout {
+                    id: bubblesLayout
+                    title.text: i18n.tr("Notification Bubbles")
+                    CheckBox {
+                        id: bubblesChecked
+                        objectName: "bubblesChecked"
+                        SlotsLayout.position: SlotsLayout.Leading
+                        enabled: entry ? entry.enableNotifications : false
+                        checked: entry ? entry.bubblesNotify : false
+
+                        onCheckedChanged: {
+                            ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.BubblesNotify,
+                                                                    appNotificationsPage.entryIndex,
+                                                                    checked)
+                            disableNotificationsWhenAllUnchecked()
+                        }
+                    }
+                }
+            }
+
+            ListItem {
+                height: listLayout.height + (divider.visible ? divider.height : 0)
+                visible: entry ? entry.enableNotifications : false
+                ListItemLayout {
+                    id: listLayout
+                    title.text: i18n.tr("Notification List")
+                    CheckBox {
+                        id: listChecked
+                        objectName: "listChecked"
+                        SlotsLayout.position: SlotsLayout.Leading
+                        enabled: entry ? entry.enableNotifications : false
+                        checked: entry ? entry.listNotify : false
+
+                        onCheckedChanged: {
+                            ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.ListNotify,
+                                                                    appNotificationsPage.entryIndex,
+                                                                    checked)
+                            disableNotificationsWhenAllUnchecked()
+                        }
                     }
                 }
             }
         }
 
-        ListItem {
-            ListItemLayout {
-                title.text: i18n.tr("Let this app alert me using:")
-                title.color: theme.palette.normal.backgroundSecondaryText
-            }
-        }
-
-        ListItem {
-            height: soundsLayout.height + (divider.visible ? divider.height : 0)
-            ListItemLayout {
-                id: soundsLayout
-                title.text: i18n.tr("Sounds")
-                CheckBox {
-                    id: soundsChecked
-                    objectName: "soundsChecked"
-                    SlotsLayout.position: SlotsLayout.Leading
-                    enabled: entry ? entry.enableNotifications : false
-                    checked: entry ? entry.soundsNotify : false
-
-                    onCheckedChanged: {
-                        ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.SoundsNotify,
-                                                                appNotificationsPage.entryIndex,
-                                                                checked)
-                        disableNotificationsWhenAllUnchecked()
-                    }
-                }
-            }
-        }
-
-        ListItem {
-            height: vibrationsLayout.height + (divider.visible ? divider.height : 0)
-            ListItemLayout {
-                id: vibrationsLayout
-                title.text: i18n.tr("Vibrations")
-                CheckBox {
-                    id: vibrationsChecked
-                    objectName: "vibrationsChecked"
-                    SlotsLayout.position: SlotsLayout.Leading
-                    enabled: entry ? entry.enableNotifications : false
-                    checked: entry ? entry.vibrationsNotify : false
-
-                    onCheckedChanged: {
-                        ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.VibrationsNotify,
-                                                                appNotificationsPage.entryIndex,
-                                                                checked)
-                        disableNotificationsWhenAllUnchecked()
-                    }
-                }
-            }
-        }
-
-        ListItem {
-            height: bubblesLayout.height + (divider.visible ? divider.height : 0)
-            ListItemLayout {
-                id: bubblesLayout
-                title.text: i18n.tr("Notification Bubbles")
-                CheckBox {
-                    id: bubblesChecked
-                    objectName: "bubblesChecked"
-                    SlotsLayout.position: SlotsLayout.Leading
-                    enabled: entry ? entry.enableNotifications : false
-                    checked: entry ? entry.bubblesNotify : false
-
-                    onCheckedChanged: {
-                        ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.BubblesNotify,
-                                                                appNotificationsPage.entryIndex,
-                                                                checked)
-                        disableNotificationsWhenAllUnchecked()
-                    }
-                }
-            }
-        }
-
-        ListItem {
-            height: listLayout.height + (divider.visible ? divider.height : 0)
-            ListItemLayout {
-                id: listLayout
-                title.text: i18n.tr("Notification List")
-                CheckBox {
-                    id: listChecked
-                    objectName: "listChecked"
-                    SlotsLayout.position: SlotsLayout.Leading
-                    enabled: entry ? entry.enableNotifications : false
-                    checked: entry ? entry.listNotify : false
-
-                    onCheckedChanged: {
-                        ClickApplicationsModel.setNotifyEnabled(ClickApplicationsModel.ListNotify,
-                                                                appNotificationsPage.entryIndex,
-                                                                checked)
-                        disableNotificationsWhenAllUnchecked()
-                    }
-                }
-            }
-        }
     }
+
 }

--- a/plugins/notifications/ClickAppNotifications.qml
+++ b/plugins/notifications/ClickAppNotifications.qml
@@ -26,6 +26,7 @@ ItemPage {
 
     property var entry
     property int entryIndex
+
     title: entry ? entry.displayName : ""
     flickable: clickAppNotificationsFlickable
 

--- a/plugins/notifications/ClickAppNotifications.qml
+++ b/plugins/notifications/ClickAppNotifications.qml
@@ -21,16 +21,13 @@ import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.Notifications 1.0
 import SystemSettings 1.0
 
-Page {
+ItemPage {
     id: appNotificationsPage
 
     property var entry
     property int entryIndex
-
-    header: PageHeader {
-        id: pageHeader
-        title: entry ? entry.displayName : ""
-    }
+    title: entry ? entry.displayName : ""
+    flickable: clickAppNotificationsFlickable
 
     function disableNotificationsWhenAllUnchecked() {
         if (!entry) {
@@ -48,13 +45,9 @@ Page {
     Flickable {
         id: clickAppNotificationsFlickable
         flickableDirection: Flickable.VerticalFlick
+        contentHeight: contentItem.childrenRect.height
 
-        anchors {
-            top: pageHeader.bottom
-            left: parent.left
-            right: parent.right
-            bottom: parent.bottom
-        }
+        anchors.fill: parent
 
         Column {
             id: notificationsColumn
@@ -181,7 +174,5 @@ Page {
                 }
             }
         }
-
     }
-
 }


### PR DESCRIPTION
Turns out there's a switch in ClickAppNotifications.qml which enables
or disables all notification types for the app. It gets automatically
switched when the user disables all notification types. Problem is, it
doesn't show up... it's behind the header!

This commit changes the page around so that the switch shows correctly.
It also makes the page scrollable and fixes a couple of papercuts I saw
from playing around with it. Now when the switch becomes disabled,
all of the notification-specific checkboxes don't display. When the
switch is enabled again, the checkboxes come back. Ahh, satisfying.

Closes ubports/ubuntu-touch#831