### PR TITLE
Add missing pure virtual implementation.

### DIFF
--- a/tests/plugins/security-privacy/tst_trust_store_model.cpp
+++ b/tests/plugins/security-privacy/tst_trust_store_model.cpp
@@ -176,6 +176,13 @@ struct Store: public core::trust::Store
     {
     }
 
+    void remove_application(const std::string& appid)
+    {
+        m_allRequests.remove_if([&appid](core::trust::Request &r) {
+                return r.from == appid;
+            });
+    }
+
     std::shared_ptr<core::trust::Store::Query> query()
     {
         auto query =


### PR DESCRIPTION
Adds a missing implementation for a newly introduced pure virtual method
from trust-store API, for the mock. This should fix #107.