### PR TITLE
fix 169, theme change

### DIFF
--- a/plugins/battery/PageComponent.qml
+++ b/plugins/battery/PageComponent.qml
@@ -136,7 +136,8 @@ ItemPage {
 
                     ctx.save()
                     ctx.beginPath()
-                    ctx.strokeStyle = UbuntuColors.lightAubergine
+                    ctx.strokeStyle = theme.palette.normal.foregroundText
+                    ctx.fillStyle = theme.palette.normal.foregroundText
 
                     ctx.lineWidth = units.dp(2)
 

--- a/plugins/wifi/NetworkDetails.qml
+++ b/plugins/wifi/NetworkDetails.qml
@@ -74,6 +74,7 @@ ItemPage {
 
                 TextInput {
                     id: passwordField
+                    color: theme.palette.normal.foregroundText
                     readOnly: true
                     text: networkDetails.password
                     echoMode: passwordVisibleSwitch.checked ?


### PR DESCRIPTION
Fixes where password text was black on dark background for suru dark.
uses theme color for foreground text.

https://github.com/ubports/system-settings/issues/169