### PR TITLE
[click] Update to v4 api and add multi-arch support

### DIFF
--- a/plugins/system-update/click/apiclient_impl.cpp
+++ b/plugins/system-update/click/apiclient_impl.cpp
@@ -66,6 +66,7 @@ void ApiClientImpl::requestMetadata(const QUrl &url,
 
     body.insert("apps", QJsonArray::fromStringList(packages));
     body.insert("channel", Helpers::getSystemCodename());
+    body.insert("architecture", Helpers::getArchitecture());
 
     QJsonDocument doc(body);
     QByteArray content = doc.toJson();

--- a/plugins/system-update/click/manager_impl.cpp
+++ b/plugins/system-update/click/manager_impl.cpp
@@ -367,16 +367,23 @@ void ManagerImpl::parseMetadata(const QJsonArray &array)
 
         foreach (const auto &value, downloads) {
             auto download_obj = value.toObject();
-            if (download_obj["channel"].toString() == Helpers::getSystemCodename()) {
+            if (download_obj["channel"].toString() == Helpers::getSystemCodename() &&
+                Helpers::isArchSupported(download_obj["architecture"].toString())) {
                 download = download_obj;
                 break;
             }
         }
 
-        // This should not happen, but better to be on the safe side
-        if (download.isEmpty()) continue;
-
         auto identifier = object["id"].toString();
+
+        // This should not happen, but better to be on the safe side
+        if (download.isEmpty()) {
+            qWarning() << "download metadata for" << identifier <<
+                          "is empty";
+            m_candidates.remove(identifier);
+            continue;
+        }
+
         auto revision = download["revision"].toInt();
         // Check if we already have it's metadata.
         auto dbUpdate = m_model->get(identifier, revision);

--- a/plugins/system-update/helpers.cpp
+++ b/plugins/system-update/helpers.cpp
@@ -38,11 +38,16 @@ QStringList Helpers::getAvailableFrameworks()
     return result;
 }
 
-std::string Helpers::getArchitecture()
+QString Helpers::getArchitecture()
 {
-    static const std::string deb_arch
+    static const QString deb_arch
         { architectureFromDpkg() };
     return deb_arch;
+}
+
+bool Helpers::isArchSupported(QString arch)
+{
+    return arch == getArchitecture() || arch == QStringLiteral("all");
 }
 
 std::vector<std::string> Helpers::listFolder(const std::string &folder,
@@ -61,7 +66,7 @@ std::vector<std::string> Helpers::listFolder(const std::string &folder,
     return result;
 }
 
-std::string Helpers::architectureFromDpkg()
+QString Helpers::architectureFromDpkg()
 {
     QString program("dpkg");
     QStringList arguments;
@@ -74,7 +79,7 @@ std::string Helpers::architectureFromDpkg()
     auto output = archDetector.readAllStandardOutput();
     auto ostr = QString::fromUtf8(output);
 
-    return ostr.trimmed().toStdString();
+    return ostr.trimmed();
 }
 
 QString Helpers::getSystemCodename()
@@ -99,7 +104,7 @@ QString Helpers::getSystemCodename()
 QString Helpers::clickMetadataUrl()
 {
     QString url = QStringLiteral(
-        "https://open-store.io/api/v3/apps/"
+        "https://open-store.io/api/v4/apps/"
     );
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     return environment.value("URL_APPS", url);
@@ -108,7 +113,7 @@ QString Helpers::clickMetadataUrl()
 QString Helpers::clickRevisionUrl()
 {
     QString url = QStringLiteral(
-        "https://open-store.io/api/v3/revisions"
+        "https://open-store.io/api/v4/revisions"
     );
     QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
     return environment.value("URL_REVISION", url);

--- a/plugins/system-update/helpers.h
+++ b/plugins/system-update/helpers.h
@@ -33,14 +33,15 @@ class Helpers
 public:
     static QString getFrameworksDir();
     static QStringList getAvailableFrameworks();
-    static std::string getArchitecture();
+    static QString getArchitecture();
     static QString getSystemCodename();
     static QString clickMetadataUrl();
     static QString clickRevisionUrl();
     static QString whichClick();
     static QString whichPkcon();
+    static bool isArchSupported(QString arch);
 private:
-    static std::string architectureFromDpkg();
+    static QString architectureFromDpkg();
     static std::vector<std::string> listFolder(const std::string &folder,
                                                const std::string &pattern);
 };

--- a/tests/plugins/system-update/tst_clickmanager.cpp
+++ b/tests/plugins/system-update/tst_clickmanager.cpp
@@ -315,6 +315,7 @@ private slots:
             "\"downloads\": ["
             "    {"
             "        \"channel\": \"xenial\","
+            "        \"architecture\": \"all\","
             "        \"version\": \"1\","
             "        \"revision\": \"1\""
             "    }"

--- a/tests/plugins/system-update/tst_helpers.cpp
+++ b/tests/plugins/system-update/tst_helpers.cpp
@@ -38,8 +38,7 @@ private slots:
     }
     void testGetArchitecture()
     {
-        QString res = QString::fromStdString(
-            UpdatePlugin::Helpers::getArchitecture());
+        QString res = UpdatePlugin::Helpers::getArchitecture();
         QVERIFY(!res.isEmpty());
     }
     void testClickMetadataUrl()
@@ -62,4 +61,3 @@ private:
 
 QTEST_GUILESS_MAIN(TstUpdatePluginHelpers)
 #include "tst_helpers.moc"
-


### PR DESCRIPTION
This updates to v4 of the open store api, this change of api is minor
and the only change is that it gives download objects for all
architectures and not just armhf,all as v3 does.

This also adds support for multi-arch