### PR TITLE
 checkbox to switch

### DIFF
--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -91,7 +91,8 @@ ItemPage {
             Menus.SliderMenu {
                 id: brightnessSlider
                 objectName: "sliderMenu"
-                enabled: indicatorPower.brightness.state != null
+                enabled: indicatorPower.brightness.state != null 
+                visible: !autoAdjustCheck.checked
                 live: true
                 minimumValue: 0.0
                 maximumValue: 100.0
@@ -116,7 +117,7 @@ ItemPage {
                 text: i18n.tr("Adjust automatically")
                 visible: brightnessPanel.powerdRunning &&
                          brightnessPanel.autoBrightnessAvailable
-                control: CheckBox {
+                control: Switch {
                     id: autoAdjustCheck
                     property bool serverChecked: gsettings.autoBrightness
                     onServerCheckedChanged: checked = serverChecked

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -84,7 +84,6 @@ ItemPage {
             SettingsItemTitle {
                 text: i18n.tr("Display brightness")
             }
-            
             /* Use the SliderMenu component instead of the Slider to avoid binding
                issues on valueChanged until LP: #1388094 is fixed.
             */
@@ -110,8 +109,8 @@ ItemPage {
                     onSyncTriggered: indicatorPower.brightness.updateState(value / 100.0)
                 }
             }
-         
-              ListItem.Standard {
+            
+            ListItem.Standard {
                 id: adjust
                 text: i18n.tr("Adjust automatically")
                 visible: brightnessPanel.powerdRunning &&

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -84,6 +84,7 @@ ItemPage {
                 text: i18n.tr("Display brightness")
                 showDivider: false
             }
+
             /* Use the SliderMenu component instead of the Slider to avoid binding
                issues on valueChanged until LP: #1388094 is fixed.
             */
@@ -109,6 +110,7 @@ ItemPage {
                     onSyncTriggered: indicatorPower.brightness.updateState(value / 100.0)
                 }
             }
+
             ListItem.Standard {
                 id: adjust
                 text: i18n.tr("Adjust automatically")

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -79,7 +79,7 @@ ItemPage {
         Column {
             anchors.left: parent.left
             anchors.right: parent.right
-            
+
             SettingsItemTitle {
                 text: i18n.tr("Display brightness")
                 showDivider: false

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -80,9 +80,9 @@ ItemPage {
             anchors.left: parent.left
             anchors.right: parent.right
             
-            //SettingsItemTitle to be consistent with the rest of settings
             SettingsItemTitle {
                 text: i18n.tr("Display brightness")
+                showDivider: false
             }
             /* Use the SliderMenu component instead of the Slider to avoid binding
                issues on valueChanged until LP: #1388094 is fixed.
@@ -130,10 +130,10 @@ ItemPage {
                 visible: adjust.visible
             }
             
-            //Clean up dividers, use SettingsItemTitle for dividing. 
             SettingsItemTitle {
                 text: i18n.tr("Display")
                 visible: brightnessPanel.widiSupported
+                showDivider: false
             }
 
             ListItem.Standard {

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -79,7 +79,37 @@ ItemPage {
         Column {
             anchors.left: parent.left
             anchors.right: parent.right
+            
+            //SettingsItemTitle to be consistent with the rest of settings
+            SettingsItemTitle {
+                text: i18n.tr("Display brightness:")
+            }
+            
+            /* Use the SliderMenu component instead of the Slider to avoid binding
+               issues on valueChanged until LP: #1388094 is fixed.
+            */
+            Menus.SliderMenu {
+                id: brightnessSlider
+                objectName: "sliderMenu"
+                enabled: indicatorPower.brightness.state != null
+                live: true
+                minimumValue: 0.0
+                maximumValue: 100.0
+                minIcon: "image://theme/display-brightness-min"
+                maxIcon: "image://theme/display-brightness-max"
 
+                property real serverValue: enabled ? indicatorPower.brightness.state * 100 : 0.0
+
+                USC.ServerPropertySynchroniser {
+                    userTarget: brightnessSlider
+                    userProperty: "value"
+                    serverTarget: brightnessSlider
+                    serverProperty: "serverValue"
+                    maximumWaitBufferInterval: 16
+
+                    onSyncTriggered: indicatorPower.brightness.updateState(value / 100.0)
+                }
+            }
          
               ListItem.Standard {
                 id: adjust
@@ -102,46 +132,10 @@ ItemPage {
                 visible: adjust.visible
             }
             
-            //SettingsItemTitle to be consistent with the rest of settings
+            //Clean up dividers, use SettingsItemTitle for dividing. 
             SettingsItemTitle {
-                text: i18n.tr("Display brightness:")
-                visible: !autoAdjustCheck.checked
-
-            }
-            
-            /* Use the SliderMenu component instead of the Slider to avoid binding
-               issues on valueChanged until LP: #1388094 is fixed.
-            */
-            Menus.SliderMenu {
-                id: brightnessSlider
-                objectName: "sliderMenu"
-                enabled: indicatorPower.brightness.state != null 
-                visible: !autoAdjustCheck.checked
-                live: true
-                minimumValue: 0.0
-                maximumValue: 100.0
-                minIcon: "image://theme/display-brightness-min"
-                maxIcon: "image://theme/display-brightness-max"
-
-                property real serverValue: enabled ? indicatorPower.brightness.state * 100 : 0.0
-
-                USC.ServerPropertySynchroniser {
-                    userTarget: brightnessSlider
-                    userProperty: "value"
-                    serverTarget: brightnessSlider
-                    serverProperty: "serverValue"
-                    maximumWaitBufferInterval: 16
-
-                    onSyncTriggered: indicatorPower.brightness.updateState(value / 100.0)
-                }
-            }
-
-          
-              //Clean up dividers, se SettingsItemTitle for dividing. 
-              SettingsItemTitle {
                 text: i18n.tr("Display")
                 visible: brightnessPanel.widiSupported
-
             }
 
             ListItem.Standard {

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -82,7 +82,6 @@ ItemPage {
 
             SettingsItemTitle {
                 text: i18n.tr("Display brightness")
-                showDivider: false
             }
 
             /* Use the SliderMenu component instead of the Slider to avoid binding
@@ -135,7 +134,6 @@ ItemPage {
             SettingsItemTitle {
                 text: i18n.tr("Display")
                 visible: brightnessPanel.widiSupported
-                showDivider: false
             }
 
             ListItem.Standard {

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -80,9 +80,30 @@ ItemPage {
             anchors.left: parent.left
             anchors.right: parent.right
 
-            ListItem.Standard {
-                text: i18n.tr("Display brightness")
+            //consistent with the rest of settings
+            SettingsItemTitle {
+                text: i18n.tr("Brightness")
+            }
+            
+              ListItem.Standard {
+                id: adjust
+                text: i18n.tr("Adjust automatically")
+                visible: brightnessPanel.powerdRunning &&
+                         brightnessPanel.autoBrightnessAvailable
+                control: Switch {
+                    id: autoAdjustCheck
+                    property bool serverChecked: gsettings.autoBrightness
+                    onServerCheckedChanged: checked = serverChecked
+                    Component.onCompleted: checked = serverChecked
+                    onTriggered: gsettings.autoBrightness = checked
+                }
                 showDivider: false
+            }
+
+            ListItem.Caption {
+                text: i18n.tr(
+                        "Brightens and dims the display to suit the surroundings.")
+                visible: adjust.visible
             }
 
             /* Use the SliderMenu component instead of the Slider to avoid binding
@@ -112,33 +133,17 @@ ItemPage {
                 }
             }
 
-            ListItem.Standard {
-                id: adjust
-                text: i18n.tr("Adjust automatically")
-                visible: brightnessPanel.powerdRunning &&
-                         brightnessPanel.autoBrightnessAvailable
-                control: Switch {
-                    id: autoAdjustCheck
-                    property bool serverChecked: gsettings.autoBrightness
-                    onServerCheckedChanged: checked = serverChecked
-                    Component.onCompleted: checked = serverChecked
-                    onTriggered: gsettings.autoBrightness = checked
-                }
-                showDivider: false
-            }
-
-            ListItem.Caption {
-                text: i18n.tr(
-                        "Brightens and dims the display to suit the surroundings.")
-                visible: adjust.visible
-            }
-
-            ListItem.Divider {
+          
+              //Clean up dividers, se SettingsItemTitle for dividing. 
+              SettingsItemTitle {
+                text: i18n.tr("Display")
                 visible: brightnessPanel.widiSupported
+
             }
 
             ListItem.Standard {
                 text: i18n.tr("External display")
+                visible: brightnessPanel.widiSupported
                 enabled: brightnessPanel.widiSupported
                 onClicked: enabledCheck.trigger()
                 control: Switch {

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -129,7 +129,7 @@ ItemPage {
                         "Brightens and dims the display to suit the surroundings.")
                 visible: adjust.visible
             }
-            
+
             SettingsItemTitle {
                 text: i18n.tr("Display")
                 visible: brightnessPanel.widiSupported

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -109,7 +109,6 @@ ItemPage {
                     onSyncTriggered: indicatorPower.brightness.updateState(value / 100.0)
                 }
             }
-            
             ListItem.Standard {
                 id: adjust
                 text: i18n.tr("Adjust automatically")

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -82,7 +82,7 @@ ItemPage {
             
             //SettingsItemTitle to be consistent with the rest of settings
             SettingsItemTitle {
-                text: i18n.tr("Display brightness:")
+                text: i18n.tr("Display brightness")
             }
             
             /* Use the SliderMenu component instead of the Slider to avoid binding

--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -80,11 +80,7 @@ ItemPage {
             anchors.left: parent.left
             anchors.right: parent.right
 
-            //consistent with the rest of settings
-            SettingsItemTitle {
-                text: i18n.tr("Brightness")
-            }
-            
+         
               ListItem.Standard {
                 id: adjust
                 text: i18n.tr("Adjust automatically")
@@ -105,7 +101,14 @@ ItemPage {
                         "Brightens and dims the display to suit the surroundings.")
                 visible: adjust.visible
             }
+            
+            //SettingsItemTitle to be consistent with the rest of settings
+            SettingsItemTitle {
+                text: i18n.tr("Display brightness:")
+                visible: !autoAdjustCheck.checked
 
+            }
+            
             /* Use the SliderMenu component instead of the Slider to avoid binding
                issues on valueChanged until LP: #1388094 is fixed.
             */


### PR DESCRIPTION
Change single checkbox to switch to match other control interactions, hide slider when can not be used.
Fix #128 