### PR TITLE
WiFi: fix forgetting active network

### DIFF
--- a/plugins/wifi/NetworkDetailsBrief.qml
+++ b/plugins/wifi/NetworkDetailsBrief.qml
@@ -62,7 +62,8 @@ ItemPage {
                     onClicked: {
                         if (DbusHelper.forgetActiveDevice()) {
                             accessPoint.checked = false;
-                            accessPoint.checkedChanged(false)
+                            accessPoint.checkedChanged(false);
+                            pageStack.removePages(root);
                         }
                     }
                 }

--- a/plugins/wifi/wifidbushelper.cpp
+++ b/plugins/wifi/wifidbushelper.cpp
@@ -573,6 +573,7 @@ bool WifiDbusHelper::forgetActiveDevice() {
                     return false;
                 }
                 forgetConnection(conn_path_var.value<QDBusObjectPath>().path());
+                return true;
             }
             break;
         }


### PR DESCRIPTION
This fixes the problem where pressing "Forget this network" won't pop
the user out of the NetworkDetailsBreif page.

Requires 2 fixes:
- Fix the return value of WifiDbusHelper::forgetActiveDevice().
- Make NetworkDetailsBrief remove itself after successfully call the
  mentioned function.

Fixes partially https://github.com/ubports/ubuntu-touch/issues/820

P.S.: This is a bug fix and a small one. Is this eligible for inclusion in OTA-12? It can wait; the bug is just an annoyance. The intended function still works.