### PR TITLE
Make Standard dividers to be theme colored

### DIFF
--- a/src/SystemSettings/ListItems/Standard.qml
+++ b/src/SystemSettings/ListItems/Standard.qml
@@ -28,8 +28,8 @@ ListItem {
 
     height: layoutItem.height + (divider.visible ? divider.height : 0)
     divider.visible: showDivider
-    divider.colorFrom: "#EEEEEE"
-    divider.colorTo: "#EEEEEE"
+    divider.colorFrom: theme.palette.normal.base
+    divider.colorTo: theme.palette.normal.base
     divider.height: units.dp(1)
     highlightColor: highlightWhenPressed ? undefined : "transparent"
 


### PR DESCRIPTION
Use palette colors for Standard dividers:

Before
![imatge](https://user-images.githubusercontent.com/6640041/83207917-93f73d00-a154-11ea-83b5-7b05d60f13e0.png)

After
![imatge](https://user-images.githubusercontent.com/6640041/83207931-9eb1d200-a154-11ea-8c21-03f47f4ffdb3.png)

Before:
![imatge](https://user-images.githubusercontent.com/6640041/83208161-46c79b00-a155-11ea-96de-cb326de08d72.png)

After:
![imatge](https://user-images.githubusercontent.com/6640041/83208172-4d561280-a155-11ea-8405-b4997d346551.png)
