### PR TITLE
Always show the launcher settings

### DIFF
--- a/plugins/launcher/launcher.settings
+++ b/plugins/launcher/launcher.settings
@@ -10,5 +10,5 @@
     ],
     "page-component": "PageComponent.qml",
     "has-dynamic-keywords": false,
-    "has-dynamic-visibility": true
+    "has-dynamic-visibility": false
 }

--- a/plugins/launcher/plugin/launcher-plugin.cpp
+++ b/plugins/launcher/plugin/launcher-plugin.cpp
@@ -53,23 +53,7 @@ LauncherItem::LauncherItem(const QVariantMap &staticData, QObject *parent):
         }
     }
 
-    // Show only if some screen is larger than the threshold.
-    QQmlEngine engine;
-    LauncherPanelPluginImpl panel;
-    QString folder(env.value("SNAP", QString()) + LAUNCHER_PLUGIN_QML_DIR);
-    QQmlComponent guAccessorComponent(
-        &engine, QUrl::fromLocalFile(folder + "/GuAccessor.qml")
-    );
-    QScopedPointer<QObject> guAccessor(guAccessorComponent.create());
-    int largeScreenThreshold = guAccessor->property("largeScreenThreshold").toInt();
-    for (int i = 0; i < panel.screens(); i++) {
-        if (panel.screenGeometry(i).width() > largeScreenThreshold) {
-            setVisibility(true);
-            return;
-        }
-    }
-
-    setVisibility(false);
+    setVisibility(true);
 }
 
 void LauncherItem::setVisibility(bool visible)

--- a/plugins/reset/ResetLauncherHome.qml
+++ b/plugins/reset/ResetLauncherHome.qml
@@ -47,7 +47,7 @@ Component {
                 dialog.state = "clicked";
                 unitySettings.schema.reset("favorites");
                 unitySettings.schema.reset("items");
-                root.done();
+                PopupUtils.close(dialog);
             }
         }
         Button {

--- a/tests/plugins/launcher/tst_LauncherPageComponent.qml
+++ b/tests/plugins/launcher/tst_LauncherPageComponent.qml
@@ -58,22 +58,22 @@ Item {
         function test_no_always_show_launcher_switch() {
             /* I.e. No large screen is available. Assumes currentScreenNumber is 0. */
             var label = findChild(instance, "largeScreenLabel");
-            var switch = findChild(instance, "alwaysShowLauncher");
+            var toggle = findChild(instance, "alwaysShowLauncher");
             LauncherPanelPlugin.setScreenGeometry(0, 0, 0, 100, 100);
             LauncherPanelPlugin.setScreens(1);
             verify(!label.visible);
-            verify(!switch.visible);
+            verify(!toggle.visible);
         }
 
         function test_always_show_launcher_switch_show() {
             /* I.e. There's a large screen available. */
             var label = findChild(instance, "largeScreenLabel");
-            var switch = findChild(instance, "alwaysShowLauncher");
+            var toggle = findChild(instance, "alwaysShowLauncher");
             LauncherPanelPlugin.setScreenGeometry(0, 0, 0, 100, 100); // small
             LauncherPanelPlugin.setScreenGeometry(1, 0, 0, largeScreen, 100);
             LauncherPanelPlugin.setScreens(2);
             verify(label.visible);
-            verify(switch.visible);
+            verify(toggle.visible);
         }
 
         function test_always_show_launcher_switch() {

--- a/tests/plugins/launcher/tst_LauncherPageComponent.qml
+++ b/tests/plugins/launcher/tst_LauncherPageComponent.qml
@@ -54,24 +54,26 @@ Item {
         function get_gsettings_plugin() {
             return findInvisibleChild(instance, "unity8Settings");
         }
-
-        function test_no_large_screen_label_necessary() {
-            /* I.e. you're on a large screen, and the screen USS is rendered on
-            is that screen. Assumes currentScreenNumber is 0. */
+        
+        function test_no_always_show_launcher_switch() {
+            /* I.e. No large screen is available. Assumes currentScreenNumber is 0. */
             var label = findChild(instance, "largeScreenLabel");
-            LauncherPanelPlugin.setScreenGeometry(0, 0, 0, largeScreen, 100);
+            var switch = findChild(instance, "alwaysShowLauncher");
+            LauncherPanelPlugin.setScreenGeometry(0, 0, 0, 100, 100);
             LauncherPanelPlugin.setScreens(1);
             verify(!label.visible);
+            verify(!switch.visible);
         }
 
-        function test_large_screen_label_should_show() {
-            /* I.e. you're on a small screen, but there's a large screen
-            somewhere and USS is rendered onto that screen. */
+        function test_always_show_launcher_switch_show() {
+            /* I.e. There's a large screen available. */
             var label = findChild(instance, "largeScreenLabel");
+            var switch = findChild(instance, "alwaysShowLauncher");
             LauncherPanelPlugin.setScreenGeometry(0, 0, 0, 100, 100); // small
             LauncherPanelPlugin.setScreenGeometry(1, 0, 0, largeScreen, 100);
             LauncherPanelPlugin.setScreens(2);
             verify(label.visible);
+            verify(switch.visible);
         }
 
         function test_always_show_launcher_switch() {


### PR DESCRIPTION
 - The launcher is now always shown regardless if the display is large enough or not
 - "Always show launcher" toggle is only displayed when there's a large display is available
 - Added Reset Launcher button from the Reset page. Exact same functionality is used.

Sscreenshot on Nexus 5 (Note: This is very old image so the color may not be accurate)
![screenshot20200531_165912265](https://user-images.githubusercontent.com/29456786/83348534-de7fe180-a32d-11ea-8720-aee14d8c3992.png)
