### PR TITLE
Brightness slider is only interactive when auto-brightness is off

### DIFF
--- a/plugins/brightness/PageComponent.qml
+++ b/plugins/brightness/PageComponent.qml
@@ -109,6 +109,13 @@ ItemPage {
 
                     onSyncTriggered: indicatorPower.brightness.updateState(value / 100.0)
                 }
+                
+                /* Disables interaction with the slider when auto-brightness is enabled.
+                The property "enabled" cannot be used because it also disables the live update */
+                MouseArea {
+                    anchors.fill: parent
+                    enabled: gsettings.autoBrightness
+                }
             }
 
             ListItem.Standard {


### PR DESCRIPTION
Disables interaction with the brightness slider when auto-brightness is enabled.
A MouseArea is used since the enabled property of the slider also stops the live updates.

fixed #204 