### PR TITLE
Improve reliability of checking for updates

### DIFF
--- a/plugins/about/PageComponent.qml
+++ b/plugins/about/PageComponent.qml
@@ -194,12 +194,18 @@ ItemPage {
                         var upPlugin = pluginManager.getByName("system-update")
                         if (upPlugin) {
                             var updatePage = upPlugin.pageComponent
-                            var updatePageItem;
+                            var updatePageIncubator;
                             if (updatePage) {
-                                updatePageItem = pageStack.addPageToNextColumn(root, updatePage, {
+                                updatePageIncubator = pageStack.addPageToNextColumn(root, updatePage, {
                                     plugin: upPlugin, pluginManager: pluginManager
                                 });
-                                updatePageItem.check(true); // Force a check.
+                                if (updatePageIncubator && updatePageIncubator.status == Component.Loading) {
+                                    updatePageIncubator.onStatusChanged = function(status) {
+                                        if (status == Component.Ready) {
+                                            updatePageIncubator.object.check(true);
+                                        }
+                                    }
+                                }
                             } else {
                                 console.warn("Failed to get system-update pageComponent")
                             }

--- a/plugins/system-update/updatemanager.cpp
+++ b/plugins/system-update/updatemanager.cpp
@@ -150,7 +150,7 @@ bool UpdateManager::isCheckRequired()
 
 void UpdateManager::handleCheckCompleted()
 {
-    m_model->db()->setLastCheckDate(QDateTime::currentDateTime());
+    m_model->db()->setLastCheckDate(QDateTime::currentDateTimeUtc());
 }
 
 void UpdateManager::handleNetworkError()


### PR DESCRIPTION
While investigating a true fix for https://github.com/ubports/ubuntu-touch/issues/1424, I found that fixing a few easier bugs can at least make it easier for people to recover from that issue.

Reviewing each commit individually may be easier, as their messages have a better description of the issue.