### PR TITLE
Don't use strokeColor in Buttons

### DIFF
--- a/plugins/system-update/GlobalUpdateControls.qml
+++ b/plugins/system-update/GlobalUpdateControls.qml
@@ -130,7 +130,6 @@ Item {
             }
             onClicked: globalUpdateControls.requestInstall()
             color: theme.palette.normal.positive
-            strokeColor: "transparent"
         }
     }
 

--- a/plugins/system-update/ReinstallAllApps.qml
+++ b/plugins/system-update/ReinstallAllApps.qml
@@ -95,7 +95,6 @@ ItemPage {
                 text: i18n.tr("Reinstall all apps")
                 onClicked: check()
                 color: theme.palette.normal.positive
-                strokeColor: "transparent"
             }
 
             GlobalUpdateControls {


### PR DESCRIPTION
This is part of another CiberSheep plan: The strokeColor for Buttons 
I need a catchy name.

This MR will be important whe https://github.com/ubports/ubuntu-ui-toolkit/pull/88 can be solved

`strokeColor: "transparent"` seems have no difference in Button border.

![imatge](https://user-images.githubusercontent.com/6640041/89740107-626ced00-da86-11ea-9a3d-e8210240352e.png)
