### PR TITLE
 Add brightness icon in battery page

### DIFF
--- a/plugins/battery/PageComponent.qml
+++ b/plugins/battery/PageComponent.qml
@@ -296,6 +296,14 @@ ItemPage {
 
             SettingsListItems.StandardProgression {
                 text: i18n.tr("Display brightness")
+
+                Icon {
+                    width: units.gu(2.5)
+                    height: width
+                    name: "display-brightness-symbolic"
+                    SlotsLayout.position: SlotsLayout.First
+                }
+
                 onClicked: {
                     var brightnessPlugin = pluginManager.getByName("brightness");
                     if (brightnessPlugin) {


### PR DESCRIPTION
Add the brightness icon in the battery page as it was the only item without an icon in the list

![immagine](https://user-images.githubusercontent.com/28359593/94924556-076fd900-04be-11eb-845a-dc087f0734ca.png)
