### PR TITLE
Fix building system-settings app with crossbuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ __pycache__
 *.gch
 tests/autopilot/ubuntu_system_settings.egg-info/
 obj-arm-linux-gnueabihf/
+obj-aarch64-linux-gnu/
 debian/debhelper-build-stamp
 *.substvars

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,13 @@ system-settings.pro.user
 /debian/tmp/
 /debian/ubuntu-system-settings/
 /debian/ubuntu-system-settings-example/
+/debian/ubuntu-system-settings-autopilot/
 .cproject
 .project
 .settings
 __pycache__
 *.gch
+tests/autopilot/ubuntu_system_settings.egg-info/
+obj-arm-linux-gnueabihf/
+debian/debhelper-build-stamp
+*.substvars

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Ubuntu Desktop Team <ubuntu-desktop@lists.ubuntu.com>
 Build-Depends: dbus-test-runner,
                debhelper (>= 9),
-               dh-migrations,
+               dh-migrations:all,
                dh-python,
                python3-setuptools,
                python3-all:any,


### PR DESCRIPTION
Fix building system-settings app with `crossbuilder` by setting `dh-migrations` arch to `:all`

add to `.gitignore` all the files generated by the build