### PR TITLE
WIP: remove dividers

### DIFF
--- a/src/qml/CategorySection.qml
+++ b/src/qml/CategorySection.qml
@@ -101,9 +101,7 @@ Column {
 
     ListItem {
         divider {
-            visible: true
-            colorFrom: "#EEEEEE"
-            colorTo: "#EEEEEE"
+            visible: false
         }
         visible: header.visible && container.layout == "grid"
         height: divider.height

--- a/src/qml/CategorySection.qml
+++ b/src/qml/CategorySection.qml
@@ -99,11 +99,4 @@ Column {
         }
     }
 
-    ListItem {
-        divider {
-            visible: false
-        }
-        visible: header.visible && container.layout == "grid"
-        height: divider.height
-    }
 }


### PR DESCRIPTION
remove dividers in grid layout, in favor of spacing - should also fix the buggy text overlaps when wordwrap or searching.
