### PR TITLE
Fix app icon in storage page

### DIFF
--- a/plugins/about/click.cpp
+++ b/plugins/about/click.cpp
@@ -80,7 +80,7 @@ void ClickModel::populateFromDesktopOrIniFile (Click *newClick,
                 desktopOrIniFileName =
                         g_strdup(desktopOrIniFile.fileName().toLocal8Bit().constData());
                 if (!desktopOrIniFile.exists())
-                    goto out;
+                    continue;
 
                 /* replace directory so the icon is correctly loaded */
                 directory = scopeDirectory;
@@ -97,7 +97,7 @@ void ClickModel::populateFromDesktopOrIniFile (Click *newClick,
                    g_strdup(desktopOrIniFile.fileName().toLocal8Bit().constData());
 
                 if (!desktopOrIniFile.exists())
-                    goto out;
+                    continue;
             }
 
             g_debug ("Desktop or ini file: %s", desktopOrIniFileName);
@@ -111,7 +111,7 @@ void ClickModel::populateFromDesktopOrIniFile (Click *newClick,
 
             if (!loaded) {
                 g_warning ("Couldn't parse desktop or ini file %s", desktopOrIniFileName);
-                goto out;
+                continue;
             }
 
             gchar * name = g_key_file_get_locale_string (appinfo,
@@ -149,14 +149,12 @@ void ClickModel::populateFromDesktopOrIniFile (Click *newClick,
                     else if (QIcon::hasThemeIcon(qIcon)) // try the icon theme
                         newClick->icon = QString("icon://theme/%1").arg(qIcon);
                 }
-                goto out;
+                continue;
             }
         }
-out:
-        g_free (desktopOrIniFileName);
-        g_key_file_free (appinfo);
-        return;
     }
+    g_free (desktopOrIniFileName);
+    g_key_file_free (appinfo);
 }
 
 ClickModel::Click ClickModel::buildClick(QVariantMap manifest)


### PR DESCRIPTION
TELEports had the issue of not showing its icon in the storage page. This happened because TELEports is one of the rare apps that have 2 hooks in its manifest. The while loop was always returning at the first iteration, that is sufficient for most of the apps to find the `desktop` entry in the hook but in TELEports the push hook is analyzed first, and that one doesn't have the `desktop` entry, and thus the code wasn't able to find the icon that is declared in the desktop file.

This PR will let the while loop to iterate over all the hooks the apps have so that the desktop entry can always be found and the icon can be properly located.

Some apps (like Notes) solved this issue with the `icon` field in the manifest, which gets overwritten by the path to the icon found in the desktop file only if the latter is valid (that means always except apps that have more than one hook in the manifest, like Notes and TELEports)

The `icon` field in the manifest may have been created for apps that don't have a desktop file (like [HTOP](https://open-store.io/app/htop.emanuelesorce)) that aren't shown in the app drawer but still have the possibility to show a custom icon in the storage settings page instead of the grey cross

Discussion about this issue [here](https://gitlab.com/ubports/apps/teleports/-/merge_requests/361)

![immagine](https://user-images.githubusercontent.com/28359593/97560035-774e8200-19de-11eb-9c86-7406d56cf8ab.png)![immagine](https://user-images.githubusercontent.com/28359593/97560016-70c00a80-19de-11eb-9a06-6e9a0f14f15f.png)
