### PR TITLE
Add more categories in the storage bar

### DIFF
--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -189,14 +189,6 @@ ItemPage {
                 StorageBar {
                     ready: backendInfo.ready
                 }
-                
-                StorageItem {
-                    objectName: "storageItem"
-                    colorName: theme.palette.normal.foreground
-                    label: i18n.tr("Free space")
-                    value: freediskSpace
-                    ready: backendInfo.ready
-                }
 
                 Repeater {
                     model: spaceColors
@@ -208,6 +200,14 @@ ItemPage {
                         value: spaceValues[index]
                         ready: backendInfo.ready
                     }
+                }
+
+                StorageItem {
+                    objectName: "storageItem"
+                    colorName: theme.palette.normal.foreground
+                    label: i18n.tr("Free space")
+                    value: freediskSpace
+                    ready: backendInfo.ready
                 }
 
                 ListItem {

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -90,16 +90,29 @@ ItemPage {
             property real otherSize: diskSpace -
                                      freediskSpace -
                                      usedByUbuntu -
-                                     backendInfo.totalClickSize -
+                                     clickAndAppDataSize -
                                      backendInfo.moviesSize -
+                                     backendInfo.audioSize -
                                      backendInfo.picturesSize -
-                                     backendInfo.audioSize
+                                     backendInfo.documentsSize -
+                                     backendInfo.downloadsSize -
+                                     backendInfo.anboxSize -
+                                     backendInfo.libertineSize
+            property real clickAndAppDataSize: backendInfo.totalClickSize +
+                                               backendInfo.appCacheSize +
+                                               backendInfo.appConfigSize +
+                                               backendInfo.appDataSize -
+                                               backendInfo.libertineSize
             //TODO: Let's consider use unified colors in a ¿file?
             property variant spaceColors: [
                 UbuntuColors.orange,
                 "#a52a00", //System Maroon
                 "#006a97", //System Blue
                 "#198400", //Dark System Green
+                "#9542c4", //from suru colors app
+                "#d07810", //from suru colors app
+                "#009688", //Anbox greenish
+                "#5d5d5d", //Libertine grey hat
                 "#f5d412", //System Yellow
                 UbuntuColors.lightAubergine]
             property variant spaceLabels: [
@@ -107,6 +120,10 @@ ItemPage {
                 i18n.tr("Videos"),
                 i18n.tr("Audio"),
                 i18n.tr("Pictures"),
+                i18n.tr("Documents"),
+                i18n.tr("Downloads"),
+                i18n.tr("Anbox"),
+                i18n.tr("Libertine"),
                 i18n.tr("Other files"),
                 i18n.tr("Used by apps")]
             property variant spaceValues: [
@@ -114,13 +131,21 @@ ItemPage {
                 backendInfo.moviesSize,
                 backendInfo.audioSize,
                 backendInfo.picturesSize,
+                backendInfo.documentsSize,
+                backendInfo.downloadsSize,
+                backendInfo.anboxSize,
+                backendInfo.libertineSize,
                 otherSize, //Other Files
-                backendInfo.totalClickSize]
+                clickAndAppDataSize]
             property variant spaceObjectNames: [
                 "usedByUbuntuItem",
                 "moviesItem",
                 "audioItem",
                 "picturesItem",
+                "documentsItem",
+                "downloadsItem",
+                "anboxItem",
+                "libertineItem",
                 "otherFilesItem",
                 "usedByAppsItem"]
 

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -105,16 +105,16 @@ ItemPage {
                                                backendInfo.libertineSize
             //TODO: Let's consider use unified colors in a ¿file?
             property variant spaceColors: [
-                UbuntuColors.orange,
-                "#a52a00", //System Maroon
-                "#006a97", //System Blue
-                "#198400", //Dark System Green
-                "#9542c4", //from suru colors app
-                "#d07810", //from suru colors app
-                "#009688", //Anbox greenish
-                "#5d5d5d", //Libertine grey hat
-                "#f5d412", //System Yellow
-                UbuntuColors.lightAubergine]
+                "#f67936",
+                "#f8ae46",
+                "#edb55f",
+                "#d1c35f",
+                "#9dd93f",
+                "#82ce5f",
+                "#76a8b6",
+                "#8891c1",
+                "#a77eaa",
+                "#cb556c"]
             property variant spaceLabels: [
                 i18n.tr("Used by Ubuntu"),
                 i18n.tr("Videos"),

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -167,110 +167,110 @@ ItemPage {
             }
 
             Flickable {
-        id: scrollWidget
-        anchors.fill: parent
-        contentHeight: columnId.height
+            id: scrollWidget
+            anchors.fill: parent
+            contentHeight: columnId.height
 
-        Component.onCompleted: storagePage.flickable = scrollWidget
+            Component.onCompleted: storagePage.flickable = scrollWidget
 
-        Column {
-            id: columnId
-            anchors.left: parent.left
-            anchors.right: parent.right
-
-            SettingsListItems.SingleValue {
-                id: diskItem
-                objectName: "diskItem"
-                text: i18n.tr("Total storage")
-                value: Utilities.formatSize(diskSpace)
-                showDivider: false
-            }
-
-            StorageBar {
-                ready: backendInfo.ready
-            }
-
-            StorageItem {
-                objectName: "storageItem"
-                colorName: theme.palette.normal.foreground
-                label: i18n.tr("Free space")
-                value: freediskSpace
-                ready: backendInfo.ready
-            }
-
-            Repeater {
-                model: spaceColors
-
-                StorageItem {
-                    objectName: spaceObjectNames[index]
-                    colorName: modelData
-                    label: spaceLabels[index]
-                    value: spaceValues[index]
-                    ready: backendInfo.ready
-                }
-            }
-
-            ListItem {
-                objectName: "installedAppsItemSelector"
-                height: layout.height + (divider.visible ? divider.height : 0)
-                divider.visible: false
-                SlotsLayout {
-                    id: layout
-                    mainSlot: OptionSelector {
-                        id: valueSelect
-                        width: parent.width - 2 * (layout.padding.leading + layout.padding.trailing)
-                        model: [i18n.tr("By name"), i18n.tr("By size")]
-                        onSelectedIndexChanged:
-                            settingsId.storageSortByName = (selectedIndex == 0)
-                                                           // 0 → by name, 1 → by size
-                    }
-                }
-            }
-
-            Binding {
-                target: valueSelect
-                property: 'selectedIndex'
-                value: (backendInfo.sortRole === ClickRoles.DisplayNameRole) ?
-                        0 :
-                        1
-            }
-
-            ListView {
-                objectName: "installedAppsListView"
+            Column {
+                id: columnId
                 anchors.left: parent.left
                 anchors.right: parent.right
-                height: childrenRect.height
-                /* Deactivate the listview flicking, we want to scroll on the
-                 * column */
-                interactive: false
-                model: backendInfo.clickList
-                delegate: ListItem {
-                    objectName: "appItem" + displayName
-                    height: appItemLayout.height + (divider.visible ? divider.height : 0)
 
-                    ListItemLayout {
-                        id: appItemLayout
-                        title.text: displayName
-                        height: units.gu(6)
+                SettingsListItems.SingleValue {
+                    id: diskItem
+                    objectName: "diskItem"
+                    text: i18n.tr("Total storage")
+                    value: Utilities.formatSize(diskSpace)
+                    showDivider: false
+                }
 
-                        IconWithFallback {
-                            SlotsLayout.position: SlotsLayout.First
-                            height: units.gu(4)
-                            source: iconPath
-                            fallbackSource: "image://theme/clear"
+                StorageBar {
+                    ready: backendInfo.ready
+                }
+                
+                StorageItem {
+                    objectName: "storageItem"
+                    colorName: theme.palette.normal.foreground
+                    label: i18n.tr("Free space")
+                    value: freediskSpace
+                    ready: backendInfo.ready
+                }
+
+                Repeater {
+                    model: spaceColors
+
+                    StorageItem {
+                        objectName: spaceObjectNames[index]
+                        colorName: modelData
+                        label: spaceLabels[index]
+                        value: spaceValues[index]
+                        ready: backendInfo.ready
+                    }
+                }
+
+                ListItem {
+                    objectName: "installedAppsItemSelector"
+                    height: layout.height + (divider.visible ? divider.height : 0)
+                    divider.visible: false
+                    SlotsLayout {
+                        id: layout
+                        mainSlot: OptionSelector {
+                            id: valueSelect
+                            width: parent.width - 2 * (layout.padding.leading + layout.padding.trailing)
+                            model: [i18n.tr("By name"), i18n.tr("By size")]
+                            onSelectedIndexChanged:
+                                settingsId.storageSortByName = (selectedIndex == 0)
+                                                               // 0 → by name, 1 → by size
                         }
-                        Label {
-                            SlotsLayout.position: SlotsLayout.Last
-                            horizontalAlignment: Text.AlignRight
-                            text: installedSize ?
-                                    Utilities.formatSize(installedSize) :
-                                    i18n.tr("N/A")
+                    }
+                }
+
+                Binding {
+                    target: valueSelect
+                    property: 'selectedIndex'
+                    value: (backendInfo.sortRole === ClickRoles.DisplayNameRole) ?
+                            0 :
+                            1
+                }
+
+                ListView {
+                    objectName: "installedAppsListView"
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    height: childrenRect.height
+                    /* Deactivate the listview flicking, we want to scroll on the
+                     * column */
+                    interactive: false
+                    model: backendInfo.clickList
+                    delegate: ListItem {
+                        objectName: "appItem" + displayName
+                        height: appItemLayout.height + (divider.visible ? divider.height : 0)
+
+                        ListItemLayout {
+                            id: appItemLayout
+                            title.text: displayName
+                            height: units.gu(6)
+
+                            IconWithFallback {
+                                SlotsLayout.position: SlotsLayout.First
+                                height: units.gu(4)
+                                source: iconPath
+                                fallbackSource: "image://theme/clear"
+                            }
+                            Label {
+                                SlotsLayout.position: SlotsLayout.Last
+                                horizontalAlignment: Text.AlignRight
+                                text: installedSize ?
+                                        Utilities.formatSize(installedSize) :
+                                        i18n.tr("N/A")
+                            }
                         }
                     }
                 }
             }
         }
-    }
         }
     }
 }

--- a/plugins/about/StorageBar.qml
+++ b/plugins/about/StorageBar.qml
@@ -30,6 +30,7 @@ Item {
         anchors.fill: parent
 
         Repeater {
+            id: colorsRepeater
             model: spaceColors
 
             Rectangle {
@@ -41,6 +42,22 @@ Item {
                         duration: UbuntuAnimation.SlowDuration
                         easing: UbuntuAnimation.StandardEasing
                     }
+                }
+                Rectangle {
+                    height: parent.height
+                    width: Math.min(units.dp(1), parent.width) / 2
+                    color: theme.palette.normal.background
+                    anchors.left: parent.left
+                    z: parent.z +1
+                    visible: index != 0
+                }
+                Rectangle {
+                    height: parent.height
+                    width: Math.min(units.dp(1), parent.width) / 2
+                    color: theme.palette.normal.background
+                    anchors.right: parent.right
+                    z: parent.z +1
+                    visible: index != colorsRepeater.count - 1
                 }
             }
         }

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -143,8 +143,15 @@ StorageAbout::StorageAbout(QObject *parent) :
     m_moviesSize(0),
     m_audioSize(0),
     m_picturesSize(0),
+    m_documentsSize(0),
+    m_downloadsSize(0),
     m_otherSize(0),
     m_homeSize(0),
+    m_anboxSize(0),
+    m_libertineSize(0),
+    m_appCacheSize(0),
+    m_appConfigSize(0),
+    m_appDataSize(0),
     m_propertyService(new QDBusInterface(PROPERTY_SERVICE_OBJ,
         PROPERTY_SERVICE_PATH,
         PROPERTY_SERVICE_OBJ,
@@ -296,10 +303,46 @@ quint64 StorageAbout::getPicturesSize()
     return m_picturesSize;
 }
 
+quint64 StorageAbout::getDocumentsSize()
+{
+    return m_documentsSize;
+}
+
+quint64 StorageAbout::getDownloadsSize()
+{
+    return m_downloadsSize;
+}
+
 quint64 StorageAbout::getHomeSize()
 {
     return m_homeSize;
 }
+
+quint64 StorageAbout::getAnboxSize()
+{
+    return m_anboxSize;
+}
+
+quint64 StorageAbout::getLibertineSize()
+{
+    return m_libertineSize;
+}
+
+quint64 StorageAbout::getAppCacheSize()
+{
+    return m_appCacheSize;
+}
+
+quint64 StorageAbout::getAppConfigSize()
+{
+    return m_appConfigSize;
+}
+
+quint64 StorageAbout::getAppDataSize()
+{
+    return m_appDataSize;
+}
+
 
 void StorageAbout::populateSizes()
 {
@@ -327,10 +370,52 @@ void StorageAbout::populateSizes()
                 new MeasureData(running_ptr, this, &m_picturesSize,
                                 m_cancellable));
 
+    measure_special_file(
+                G_USER_DIRECTORY_DOCUMENTS,
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_documentsSize,
+                                m_cancellable));
+
+    measure_special_file(
+                G_USER_DIRECTORY_DOWNLOAD,
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_downloadsSize,
+                                m_cancellable));
+
     measure_file(
                 g_get_home_dir(),
                 measure_finished,
                 new MeasureData(running_ptr, this, &m_homeSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/anbox-data",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_anboxSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.cache/libertine-container",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_libertineSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.cache",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_appCacheSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.config",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_appConfigSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.local/share",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_appDataSize,
                                 m_cancellable));
 }
 
@@ -352,7 +437,7 @@ void StorageAbout::prepareMountedVolumes()
             /* Only check devices once */
             if (checked.contains(drive))
                 continue;
-             
+
             checked.append(drive);
             QString devicePath(getDevicePath(drive));
             if (devicePath.isEmpty() || m_mountedVolumes.contains(drive))

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -70,8 +70,36 @@ class StorageAbout : public QObject
                READ getPicturesSize
                NOTIFY sizeReady)
 
+    Q_PROPERTY(quint64 documentsSize
+               READ getDocumentsSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 downloadsSize
+               READ getDownloadsSize
+               NOTIFY sizeReady)
+
     Q_PROPERTY(quint64 homeSize
                READ getHomeSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 anboxSize
+               READ getAnboxSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 libertineSize
+               READ getLibertineSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 appCacheSize
+               READ getAppCacheSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 appConfigSize
+               READ getAppConfigSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 appDataSize
+               READ getAppDataSize
                NOTIFY sizeReady)
 
     Q_PROPERTY(ClickModel::Roles sortRole
@@ -109,7 +137,14 @@ public:
     quint64 getMoviesSize();
     quint64 getAudioSize();
     quint64 getPicturesSize();
+    quint64 getDocumentsSize();
+    quint64 getDownloadsSize();
     quint64 getHomeSize();
+    quint64 getAnboxSize();
+    quint64 getLibertineSize();
+    quint64 getAppCacheSize();
+    quint64 getAppConfigSize();
+    quint64 getAppDataSize();
     Q_INVOKABLE void populateSizes();
     QStringList getMountedVolumes();
     Q_INVOKABLE QString getDevicePath (const QString mount_point) const;
@@ -136,8 +171,15 @@ private:
     quint64 m_moviesSize;
     quint64 m_audioSize;
     quint64 m_picturesSize;
+    quint64 m_documentsSize;
+    quint64 m_downloadsSize;
     quint64 m_otherSize;
     quint64 m_homeSize;
+    quint64 m_anboxSize;
+    quint64 m_libertineSize;
+    quint64 m_appCacheSize;
+    quint64 m_appConfigSize;
+    quint64 m_appDataSize;
 
     QMap<QString, QString> m_mounts;
 


### PR DESCRIPTION
The "Other files" category in _About -> Storage_ was a bit too vague for me, so I thought to add more detailed categories:

- Documents (`~/Documents`)
- Downloads (`~/Downloads`)
- Anbox (`~/anbox-data`)
- Libertine (`~/.cache/libertine-container`)

I also included `~/.cache` (except `libertine-container`), `~/.config` and `~/.local/share` under Used by apps

Adding four colors to the previous palette wasn't trivial so I took this new colors from baobab

I moved the Free space item in the list at the bottom, to reflect the order in the bar

![image](https://user-images.githubusercontent.com/28359593/98371787-05f57b80-203d-11eb-8977-74c3037fc4f9.png) ![image](https://user-images.githubusercontent.com/28359593/98371807-0e4db680-203d-11eb-97c6-630201473de4.png)
