### PR TITLE
Uninstall and clear data in storage settings

### DIFF
--- a/plugins/about/CMakeLists.txt
+++ b/plugins/about/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(UbuntuStorageAboutPanel MODULE
     ${QML_SOURCES} # So they show up in Qt designer.
 )
 
-target_link_libraries(UbuntuStorageAboutPanel Qt5::Qml Qt5::Quick Qt5::DBus
+target_link_libraries(UbuntuStorageAboutPanel Qt5::Qml Qt5::Quick Qt5::DBus Qt5::Concurrent
 ${ANDR_PROP_LDFLAGS} ${GLIB_LDFLAGS} ${GIO_LDFLAGS} ${CLICK_LDFLAGS} uss-systemimage)
 
 

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -18,12 +18,13 @@
  */
 
 import GSettings 1.0
-import QtQuick 2.4
+import QtQuick 2.9
 import QtSystemInfo 5.0
 import SystemSettings 1.0
 import SystemSettings.ListItems 1.0 as SettingsListItems
 import Ubuntu.Components 1.3
 import Ubuntu.SystemSettings.StorageAbout 1.0
+import QtQuick.Layouts 1.3
 
 ItemPage {
     id: storagePage
@@ -227,9 +228,45 @@ ItemPage {
                 }
             }
 
-            Binding {
-                target: valueSelect
-                property: 'selectedIndex'
+                    ListItem {
+                        height: rowL.height + (divider.visible ? divider.height : 0) + units.gu(1)
+                        divider.visible: false
+                        RowLayout {
+                            id: rowL
+                            width: parent.width - units.gu(4)
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            anchors.top: parent.top
+                            spacing: 0
+                            Repeater {
+                                id: repeater
+                                model: [
+                                {text: i18n.tr("Installed"), color: "#f89b0f"},
+                                {text: i18n.tr("Config"), color: "#0e8cba"},
+                                {text: i18n.tr("Data"), color: "#198400"},
+                                {text: i18n.tr("Cache"), color: "#ec2259"}
+                                ]
+                                Label {
+                                    Layout.fillWidth: true
+                                    text: modelData.text
+                                    textSize: Label.Small
+                                    color: theme.palette.normal.backgroundSecondaryText
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.preferredHeight: contentHeight + underline.height + units.gu(0.5)
+                                    Rectangle {
+                                        id: underline
+                                        color: modelData.color
+                                        width: parent.width
+                                        height: units.gu(0.75)
+                                        anchors.bottom: parent.bottom
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Binding {
+                        target: valueSelect
+                        property: 'selectedIndex'
                 value: (backendInfo.sortRole === ClickRoles.DisplayNameRole) ?
                         0 :
                         1
@@ -246,12 +283,11 @@ ItemPage {
                 model: backendInfo.clickList
                 delegate: ListItem {
                     objectName: "appItem" + displayName
-                    height: appItemLayout.height + (divider.visible ? divider.height : 0)
+                            height: appItemLayout.height + appStorageBar.height + (divider.visible ? divider.height : 0)
 
                     ListItemLayout {
                         id: appItemLayout
                         title.text: displayName
-                                subtitle.text: "Cache: " + Utilities.formatSize(cacheSize) + "\tConfig: " + Utilities.formatSize(configSize)  + "\tData: " + Utilities.formatSize(dataSize)
                         height: units.gu(6)
 
                         IconWithFallback {
@@ -264,13 +300,25 @@ ItemPage {
                             SlotsLayout.position: SlotsLayout.Last
                             horizontalAlignment: Text.AlignRight
                             text: installedSize ?
-                                    Utilities.formatSize(installedSize) :
-                                    i18n.tr("N/A")
+                                            Utilities.formatSize(appTotalSize) :
+                                            i18n.tr("N/A")
+                                }
+                            }
+                            StorageBar {
+                                id: appStorageBar
+                                anchors {
+                                    top: appItemLayout.bottom
+                                }
+                                height: units.gu(2)
+                                barHeight: units.gu(1)
+                                model: ["#f89b0f", "#0e8cba", "#198400", "#ec2259"]
+                                segments: [installedSize, configSize, dataSize, cacheSize]
+                                totalBar: appTotalSize
+                                ready: true
+                            }
                         }
                     }
                 }
-            }
-        }
     }
         }
     }

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -241,8 +241,18 @@ ItemPage {
                             mainSlot: OptionSelector {
                                 id: valueSelect
                                 width: parent.width - 2 * (layout.padding.leading + layout.padding.trailing)
-                                model: [i18n.tr("By name"), i18n.tr("By installation size"), i18n.tr("By cache size"), i18n.tr("By config size"), i18n.tr("By data size"), i18n.tr("By total size")]
+                                model: [
+                                i18n.tr("By name"),
+                                i18n.tr("By installation size"),
+                                i18n.tr("By cache size"),
+                                i18n.tr("By config size"),
+                                i18n.tr("By data size"),
+                                i18n.tr("By total size")
+                                ]
                                 onSelectedIndexChanged: {
+                                    // collapse the expanded ListItem
+                                    listView.ViewItems.expandedIndices = []
+
                                     switch (selectedIndex) {
                                     case 0: default:
                                         settingsId.storageSort = "name"
@@ -302,6 +312,7 @@ ItemPage {
                         interactive: false
                         model: backendInfo.clickList
                         ViewItems.expansionFlags: ViewItems.CollapseOnOutsidePress
+                        ViewItems.expandedIndices: [0]
                         delegate: ListItem {
                             id: appListItem
                             objectName: "appItem" + displayName

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -90,16 +90,29 @@ ItemPage {
             property real otherSize: diskSpace -
                                      freediskSpace -
                                      usedByUbuntu -
-                                     backendInfo.totalClickSize -
+                                     clickAndAppDataSize -
                                      backendInfo.moviesSize -
+                                     backendInfo.audioSize -
                                      backendInfo.picturesSize -
-                                     backendInfo.audioSize
+                                     backendInfo.documentsSize -
+                                     backendInfo.downloadsSize -
+                                     backendInfo.anboxSize -
+                                     backendInfo.libertineSize
+            property real clickAndAppDataSize: backendInfo.totalClickSize +
+                                               backendInfo.appCacheSize +
+                                               backendInfo.appConfigSize +
+                                               backendInfo.appDataSize -
+                                               backendInfo.libertineSize
             //TODO: Let's consider use unified colors in a ¿file?
             property variant spaceColors: [
                 UbuntuColors.orange,
                 "#a52a00", //System Maroon
                 "#006a97", //System Blue
                 "#198400", //Dark System Green
+                "#9542c4", //from suru colors app
+                "#d07810", //from suru colors app
+                "#009688", //Anbox greenish
+                "#5d5d5d", //Libertine grey hat
                 "#f5d412", //System Yellow
                 UbuntuColors.lightAubergine]
             property variant spaceLabels: [
@@ -107,6 +120,10 @@ ItemPage {
                 i18n.tr("Videos"),
                 i18n.tr("Audio"),
                 i18n.tr("Pictures"),
+                i18n.tr("Documents"),
+                i18n.tr("Downloads"),
+                i18n.tr("Anbox"),
+                i18n.tr("Libertine"),
                 i18n.tr("Other files"),
                 i18n.tr("Used by apps")]
             property variant spaceValues: [
@@ -114,13 +131,21 @@ ItemPage {
                 backendInfo.moviesSize,
                 backendInfo.audioSize,
                 backendInfo.picturesSize,
+                backendInfo.documentsSize,
+                backendInfo.downloadsSize,
+                backendInfo.anboxSize,
+                backendInfo.libertineSize,
                 otherSize, //Other Files
-                backendInfo.totalClickSize]
+                clickAndAppDataSize]
             property variant spaceObjectNames: [
                 "usedByUbuntuItem",
                 "moviesItem",
                 "audioItem",
                 "picturesItem",
+                "documentsItem",
+                "downloadsItem",
+                "anboxItem",
+                "libertineItem",
                 "otherFilesItem",
                 "usedByAppsItem"]
 

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -174,6 +174,7 @@ ItemPage {
                     parent: scrollWidget
                     refreshing: backendInfo.refreshing
                     onRefresh: backendInfo.refreshAsync()
+                    enabled: backendInfo.ready
                 }
 
                 Column {

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -189,6 +189,12 @@ ItemPage {
 
                 Component.onCompleted: storagePage.flickable = scrollWidget
 
+                PullToRefresh {
+                    parent: scrollWidget
+                    refreshing: backendInfo.refreshing
+                    onRefresh: backendInfo.refreshAsync()
+                }
+
                 Column {
                     id: columnId
                     anchors.left: parent.left
@@ -454,7 +460,7 @@ ItemPage {
 
                                                         if (cache)
                                                             backendInfo.clearAppCache(appId)
-                                                        backendInfo.refresh();
+                                                        backendInfo.refreshAsync();
                                                     })
                                                 }
                                                 function updateText() {
@@ -492,7 +498,7 @@ ItemPage {
 
                                                         if (cache)
                                                             backendInfo.clearAppCache(appId)
-                                                        backendInfo.refresh();
+                                                        backendInfo.refreshAsync();
                                                     })
                                                 }
                                                 function updateText() {

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -92,29 +92,16 @@ ItemPage {
             property real otherSize: diskSpace -
                                      freediskSpace -
                                      usedByUbuntu -
-                                     clickAndAppDataSize -
+                                     backendInfo.totalClickSize -
                                      backendInfo.moviesSize -
-                                     backendInfo.audioSize -
                                      backendInfo.picturesSize -
-                                     backendInfo.documentsSize -
-                                     backendInfo.downloadsSize -
-                                     backendInfo.anboxSize -
-                                     backendInfo.libertineSize
-            property real clickAndAppDataSize: backendInfo.totalClickSize +
-                                               backendInfo.appCacheSize +
-                                               backendInfo.appConfigSize +
-                                               backendInfo.appDataSize -
-                                               backendInfo.libertineSize
+                                     backendInfo.audioSize
             //TODO: Let's consider use unified colors in a ¿file?
             property variant spaceColors: [
                 UbuntuColors.orange,
                 "#a52a00", //System Maroon
                 "#006a97", //System Blue
                 "#198400", //Dark System Green
-                "#9542c4", //from suru colors app
-                "#d07810", //from suru colors app
-                "#009688", //Anbox greenish
-                "#5d5d5d", //Libertine grey hat
                 "#f5d412", //System Yellow
                 UbuntuColors.lightAubergine]
             property variant spaceLabels: [
@@ -122,10 +109,6 @@ ItemPage {
                 i18n.tr("Videos"),
                 i18n.tr("Audio"),
                 i18n.tr("Pictures"),
-                i18n.tr("Documents"),
-                i18n.tr("Downloads"),
-                i18n.tr("Anbox"),
-                i18n.tr("Libertine"),
                 i18n.tr("Other files"),
                 i18n.tr("Used by apps")]
             property variant spaceValues: [
@@ -133,21 +116,13 @@ ItemPage {
                 backendInfo.moviesSize,
                 backendInfo.audioSize,
                 backendInfo.picturesSize,
-                backendInfo.documentsSize,
-                backendInfo.downloadsSize,
-                backendInfo.anboxSize,
-                backendInfo.libertineSize,
                 otherSize, //Other Files
-                clickAndAppDataSize]
+                backendInfo.totalClickSize]
             property variant spaceObjectNames: [
                 "usedByUbuntuItem",
                 "moviesItem",
                 "audioItem",
                 "picturesItem",
-                "documentsItem",
-                "downloadsItem",
-                "anboxItem",
-                "libertineItem",
                 "otherFilesItem",
                 "usedByAppsItem"]
 

--- a/plugins/about/Storage.qml
+++ b/plugins/about/Storage.qml
@@ -251,6 +251,7 @@ ItemPage {
                     ListItemLayout {
                         id: appItemLayout
                         title.text: displayName
+                                subtitle.text: "Cache: " + Utilities.formatSize(cacheSize) + "\tConfig: " + Utilities.formatSize(configSize)  + "\tData: " + Utilities.formatSize(dataSize)
                         height: units.gu(6)
 
                         IconWithFallback {

--- a/plugins/about/StorageBar.qml
+++ b/plugins/about/StorageBar.qml
@@ -2,12 +2,18 @@ import QtQuick 2.4
 import Ubuntu.Components 1.3
 
 Item {
+    id: barRoot
     property bool ready: false
     anchors.horizontalCenter: parent.horizontalCenter
     height: units.gu(5)
     width: parent.width - units.gu(4)
+    property alias model: repeater.model
+    property var segments: spaceValues
+    property var totalBar: diskSpace
+    property alias barHeight: shape.height
 
     UbuntuShape {
+        id: shape
         backgroundColor: theme.palette.normal.foreground
         clip: true
         height: units.gu(3)
@@ -30,12 +36,13 @@ Item {
         anchors.fill: parent
 
         Repeater {
+            id: repeater
             model: spaceColors
 
             Rectangle {
                 color: ready ? modelData : theme.palette.disabled.base
                 height: parent.height
-                width: spaceValues[index] / diskSpace * parent.width
+                width: barRoot.segments[index] / barRoot.totalBar * parent.width
                 Behavior on color {
                     ColorAnimation {
                         duration: UbuntuAnimation.SlowDuration

--- a/plugins/about/StorageBar.qml
+++ b/plugins/about/StorageBar.qml
@@ -2,18 +2,12 @@ import QtQuick 2.4
 import Ubuntu.Components 1.3
 
 Item {
-    id: barRoot
     property bool ready: false
     anchors.horizontalCenter: parent.horizontalCenter
     height: units.gu(5)
     width: parent.width - units.gu(4)
-    property alias model: repeater.model
-    property var segments: spaceValues
-    property var totalBar: diskSpace
-    property alias barHeight: shape.height
 
     UbuntuShape {
-        id: shape
         backgroundColor: theme.palette.normal.foreground
         clip: true
         height: units.gu(3)
@@ -36,13 +30,12 @@ Item {
         anchors.fill: parent
 
         Repeater {
-            id: repeater
             model: spaceColors
 
             Rectangle {
                 color: ready ? modelData : theme.palette.disabled.base
                 height: parent.height
-                width: barRoot.segments[index] / barRoot.totalBar * parent.width
+                width: spaceValues[index] / diskSpace * parent.width
                 Behavior on color {
                     ColorAnimation {
                         duration: UbuntuAnimation.SlowDuration

--- a/plugins/about/click.cpp
+++ b/plugins/about/click.cpp
@@ -310,7 +310,7 @@ int ClickModel::columnCount(const QModelIndex &parent) const
 {
     if (parent.isValid())
         return 0;
-    return 7; //Display, total size, installed size, data size, cache size, config size, icon
+    return 9; //Display, total size, installed size, data size, cache size, config size, app id, version, icon
 }
 
 QHash<int, QByteArray> ClickModel::roleNames() const

--- a/plugins/about/click.cpp
+++ b/plugins/about/click.cpp
@@ -294,7 +294,7 @@ int ClickModel::columnCount(const QModelIndex &parent) const
 {
     if (parent.isValid())
         return 0;
-    return 3; //Display, size, icon
+    return 7; //Display, total size, installed size, data size, cache size, config size, icon
 }
 
 QHash<int, QByteArray> ClickModel::roleNames() const

--- a/plugins/about/click.cpp
+++ b/plugins/about/click.cpp
@@ -207,9 +207,9 @@ ClickModel::Click ClickModel::buildClick(QVariantMap manifest)
 
     m_totalClickSize += newClick.installSize;
 
-    QString appId = manifest.value("name","").toString();
+    newClick.appId = manifest.value("name","").toString();
 
-    QDirIterator cacheIt("/home/phablet/.cache/" + appId, QDirIterator::Subdirectories);
+    QDirIterator cacheIt("/home/phablet/.cache/" + newClick.appId, QDirIterator::Subdirectories);
     qint64 newCacheSize = 0;
     while (cacheIt.hasNext()) {
         cacheIt.next();
@@ -217,7 +217,7 @@ ClickModel::Click ClickModel::buildClick(QVariantMap manifest)
     }
     newClick.cacheSize = newCacheSize;
 
-    QDirIterator configIt("/home/phablet/.config/" + appId, QDirIterator::Subdirectories);
+    QDirIterator configIt("/home/phablet/.config/" + newClick.appId, QDirIterator::Subdirectories);
     qint64 newConfigSize = 0;
     while (configIt.hasNext()) {
         configIt.next();
@@ -225,7 +225,7 @@ ClickModel::Click ClickModel::buildClick(QVariantMap manifest)
     }
     newClick.configSize = newConfigSize;
 
-    QDirIterator dataIt("/home/phablet/.local/share/" + appId, QDirIterator::Subdirectories);
+    QDirIterator dataIt("/home/phablet/.local/share/" + newClick.appId, QDirIterator::Subdirectories);
     qint64 newDataSize = 0;
     while (dataIt.hasNext()) {
         dataIt.next();
@@ -241,6 +241,8 @@ ClickModel::Click ClickModel::buildClick(QVariantMap manifest)
     m_biggestConfigSize = std::max(newClick.configSize, m_biggestConfigSize);
     m_biggestCacheSize = std::max(newClick.cacheSize, m_biggestCacheSize);
     m_biggestInstallSize = std::max(newClick.installSize, m_biggestInstallSize);
+
+    newClick.version = manifest.value("version","").toString();
 
     return newClick;
 }
@@ -321,6 +323,8 @@ QHash<int, QByteArray> ClickModel::roleNames() const
     roleNames[ConfigSizeRole] = "configSize";
     roleNames[DataSizeRole] = "dataSize";
     roleNames[AppTotalSizeRole] = "appTotalSize";
+    roleNames[AppIdRole] = "appId";
+    roleNames[VersionRole] = "version";
     roleNames[IconRole] = "iconPath";
 
     return roleNames;
@@ -350,6 +354,10 @@ QVariant ClickModel::data(const QModelIndex &index, int role) const
         return click.dataSize;
     case AppTotalSizeRole:
         return click.appTotalSize;
+    case AppIdRole:
+        return click.appId;
+    case VersionRole:
+        return click.version;
     case IconRole:
         return click.icon;
     default:
@@ -386,6 +394,17 @@ quint64 ClickModel::getBiggestCacheSize() const
 quint64 ClickModel::getBiggestInstallSize() const
 {
     return m_biggestInstallSize;
+}
+
+void ClickModel::refresh()
+{
+    m_totalClickSize = 0;
+    m_biggestAppTotalSize = 0;
+    m_biggestDataSize = 0;
+    m_biggestConfigSize = 0;
+    m_biggestCacheSize = 0;
+    m_biggestInstallSize = 0;
+    m_clickPackages = buildClickList();
 }
 
 ClickModel::~ClickModel()

--- a/plugins/about/click.cpp
+++ b/plugins/about/click.cpp
@@ -32,8 +32,6 @@
 #include <QJsonObject>
 #include <QDirIterator>
 
-#include <algorithm>
-
 ClickModel::ClickModel(QObject *parent):
     QAbstractTableModel(parent),
     m_totalClickSize(0),
@@ -235,12 +233,12 @@ ClickModel::Click ClickModel::buildClick(QVariantMap manifest)
 
     newClick.appTotalSize = newClick.installSize + newClick.cacheSize + newClick.configSize + newClick.dataSize;
 
-    m_biggestAppTotalSize = std::max(newClick.appTotalSize, m_biggestAppTotalSize);
+    m_biggestAppTotalSize = qMax(newClick.appTotalSize, m_biggestAppTotalSize);
 
-    m_biggestDataSize = std::max(newClick.dataSize, m_biggestDataSize);
-    m_biggestConfigSize = std::max(newClick.configSize, m_biggestConfigSize);
-    m_biggestCacheSize = std::max(newClick.cacheSize, m_biggestCacheSize);
-    m_biggestInstallSize = std::max(newClick.installSize, m_biggestInstallSize);
+    m_biggestDataSize = qMax(newClick.dataSize, m_biggestDataSize);
+    m_biggestConfigSize = qMax(newClick.configSize, m_biggestConfigSize);
+    m_biggestCacheSize = qMax(newClick.cacheSize, m_biggestCacheSize);
+    m_biggestInstallSize = qMax(newClick.installSize, m_biggestInstallSize);
 
     newClick.version = manifest.value("version","").toString();
 

--- a/plugins/about/click.cpp
+++ b/plugins/about/click.cpp
@@ -32,9 +32,16 @@
 #include <QJsonObject>
 #include <QDirIterator>
 
+#include <algorithm>
+
 ClickModel::ClickModel(QObject *parent):
     QAbstractTableModel(parent),
-    m_totalClickSize(0)
+    m_totalClickSize(0),
+    m_biggestAppTotalSize(0),
+    m_biggestConfigSize(0),
+    m_biggestCacheSize(0),
+    m_biggestDataSize(0),
+    m_biggestInstallSize(0)
 {
     m_clickPackages = buildClickList();
 }
@@ -228,6 +235,13 @@ ClickModel::Click ClickModel::buildClick(QVariantMap manifest)
 
     newClick.appTotalSize = newClick.installSize + newClick.cacheSize + newClick.configSize + newClick.dataSize;
 
+    m_biggestAppTotalSize = std::max(newClick.appTotalSize, m_biggestAppTotalSize);
+
+    m_biggestDataSize = std::max(newClick.dataSize, m_biggestDataSize);
+    m_biggestConfigSize = std::max(newClick.configSize, m_biggestConfigSize);
+    m_biggestCacheSize = std::max(newClick.cacheSize, m_biggestCacheSize);
+    m_biggestInstallSize = std::max(newClick.installSize, m_biggestInstallSize);
+
     return newClick;
 }
 
@@ -347,6 +361,31 @@ QVariant ClickModel::data(const QModelIndex &index, int role) const
 quint64 ClickModel::getClickSize() const
 {
     return m_totalClickSize;
+}
+
+quint64 ClickModel::getBiggestAppTotalSize() const
+{
+    return m_biggestAppTotalSize;
+}
+
+quint64 ClickModel::getBiggestDataSize() const
+{
+    return m_biggestDataSize;
+}
+
+quint64 ClickModel::getBiggestConfigSize() const
+{
+    return m_biggestConfigSize;
+}
+
+quint64 ClickModel::getBiggestCacheSize() const
+{
+    return m_biggestCacheSize;
+}
+
+quint64 ClickModel::getBiggestInstallSize() const
+{
+    return m_biggestInstallSize;
 }
 
 ClickModel::~ClickModel()

--- a/plugins/about/click.h
+++ b/plugins/about/click.h
@@ -42,8 +42,8 @@ public:
         ConfigSizeRole = Qt::UserRole + 3,
         DataSizeRole = Qt::UserRole + 4,
         AppTotalSizeRole = Qt::UserRole + 5,
-        AppIdRole,
-        VersionRole,
+        AppIdRole = Qt::UserRole + 6,
+        VersionRole = Qt::UserRole + 7,
         IconRole
     };
 

--- a/plugins/about/click.h
+++ b/plugins/about/click.h
@@ -38,6 +38,10 @@ public:
     enum Roles {
         DisplayNameRole = Qt::DisplayRole,
         InstalledSizeRole = Qt::UserRole + 1,
+        CacheSizeRole,
+        ConfigSizeRole,
+        DataSizeRole,
+        AppTotalSizeRole,
         IconRole
     };
 
@@ -46,6 +50,10 @@ public:
         QString displayName;
         QString icon;
         uint installSize;
+        uint cacheSize;
+        uint configSize;
+        uint dataSize;
+        uint appTotalSize;
     };
 
     // implemented virtual methods from QAbstractTableModel

--- a/plugins/about/click.h
+++ b/plugins/about/click.h
@@ -38,10 +38,10 @@ public:
     enum Roles {
         DisplayNameRole = Qt::DisplayRole,
         InstalledSizeRole = Qt::UserRole + 1,
-        CacheSizeRole,
-        ConfigSizeRole,
-        DataSizeRole,
-        AppTotalSizeRole,
+        CacheSizeRole = Qt::UserRole + 2,
+        ConfigSizeRole = Qt::UserRole + 3,
+        DataSizeRole = Qt::UserRole + 4,
+        AppTotalSizeRole = Qt::UserRole + 5,
         IconRole
     };
 

--- a/plugins/about/click.h
+++ b/plugins/about/click.h
@@ -62,6 +62,11 @@ public:
     QVariant data (const QModelIndex &index, int role = Qt::DisplayRole) const;
     QHash<int, QByteArray> roleNames() const;
     quint64 getClickSize() const;
+    quint64 getBiggestAppTotalSize() const;
+    quint64 getBiggestConfigSize() const;
+    quint64 getBiggestCacheSize() const;
+    quint64 getBiggestDataSize() const;
+    quint64 getBiggestInstallSize() const;
 
 private:
     void populateFromDesktopOrIniFile(Click *newClick,
@@ -73,6 +78,11 @@ private:
 
     QList<Click> m_clickPackages;
     int m_totalClickSize;
+    uint m_biggestAppTotalSize;
+    uint m_biggestConfigSize;
+    uint m_biggestCacheSize;
+    uint m_biggestDataSize;
+    uint m_biggestInstallSize;
 
 };
 

--- a/plugins/about/click.h
+++ b/plugins/about/click.h
@@ -42,6 +42,8 @@ public:
         ConfigSizeRole = Qt::UserRole + 3,
         DataSizeRole = Qt::UserRole + 4,
         AppTotalSizeRole = Qt::UserRole + 5,
+        AppIdRole,
+        VersionRole,
         IconRole
     };
 
@@ -49,6 +51,8 @@ public:
         QString name;
         QString displayName;
         QString icon;
+        QString appId;
+        QString version;
         uint installSize;
         uint cacheSize;
         uint configSize;
@@ -67,6 +71,7 @@ public:
     quint64 getBiggestCacheSize() const;
     quint64 getBiggestDataSize() const;
     quint64 getBiggestInstallSize() const;
+    void refresh();
 
 private:
     void populateFromDesktopOrIniFile(Click *newClick,

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -148,15 +148,8 @@ StorageAbout::StorageAbout(QObject *parent) :
     m_moviesSize(0),
     m_audioSize(0),
     m_picturesSize(0),
-    m_documentsSize(0),
-    m_downloadsSize(0),
     m_otherSize(0),
     m_homeSize(0),
-    m_anboxSize(0),
-    m_libertineSize(0),
-    m_appCacheSize(0),
-    m_appConfigSize(0),
-    m_appDataSize(0),
     m_refreshing(false),
     m_refreshWatcher(),
     m_propertyService(new QDBusInterface(PROPERTY_SERVICE_OBJ,
@@ -335,46 +328,10 @@ quint64 StorageAbout::getPicturesSize()
     return m_picturesSize;
 }
 
-quint64 StorageAbout::getDocumentsSize()
-{
-    return m_documentsSize;
-}
-
-quint64 StorageAbout::getDownloadsSize()
-{
-    return m_downloadsSize;
-}
-
 quint64 StorageAbout::getHomeSize()
 {
     return m_homeSize;
 }
-
-quint64 StorageAbout::getAnboxSize()
-{
-    return m_anboxSize;
-}
-
-quint64 StorageAbout::getLibertineSize()
-{
-    return m_libertineSize;
-}
-
-quint64 StorageAbout::getAppCacheSize()
-{
-    return m_appCacheSize;
-}
-
-quint64 StorageAbout::getAppConfigSize()
-{
-    return m_appConfigSize;
-}
-
-quint64 StorageAbout::getAppDataSize()
-{
-    return m_appDataSize;
-}
-
 
 void StorageAbout::populateSizes()
 {
@@ -402,52 +359,10 @@ void StorageAbout::populateSizes()
                 new MeasureData(running_ptr, this, &m_picturesSize,
                                 m_cancellable));
 
-    measure_special_file(
-                G_USER_DIRECTORY_DOCUMENTS,
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_documentsSize,
-                                m_cancellable));
-
-    measure_special_file(
-                G_USER_DIRECTORY_DOWNLOAD,
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_downloadsSize,
-                                m_cancellable));
-
     measure_file(
                 g_get_home_dir(),
                 measure_finished,
                 new MeasureData(running_ptr, this, &m_homeSize,
-                                m_cancellable));
-
-    measure_file(
-                "/home/phablet/anbox-data",
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_anboxSize,
-                                m_cancellable));
-
-    measure_file(
-                "/home/phablet/.cache/libertine-container",
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_libertineSize,
-                                m_cancellable));
-
-    measure_file(
-                "/home/phablet/.cache",
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_appCacheSize,
-                                m_cancellable));
-
-    measure_file(
-                "/home/phablet/.config",
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_appConfigSize,
-                                m_cancellable));
-
-    measure_file(
-                "/home/phablet/.local/share",
-                measure_finished,
-                new MeasureData(running_ptr, this, &m_appDataSize,
                                 m_cancellable));
 }
 
@@ -469,7 +384,7 @@ void StorageAbout::prepareMountedVolumes()
             /* Only check devices once */
             if (checked.contains(drive))
                 continue;
-
+             
             checked.append(drive);
             QString devicePath(getDevicePath(drive));
             if (devicePath.isEmpty() || m_mountedVolumes.contains(drive))

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -384,7 +384,7 @@ void StorageAbout::prepareMountedVolumes()
             /* Only check devices once */
             if (checked.contains(drive))
                 continue;
-             
+
             checked.append(drive);
             QString devicePath(getDevicePath(drive));
             if (devicePath.isEmpty() || m_mountedVolumes.contains(drive))
@@ -554,8 +554,6 @@ void StorageAbout::clearAppData(const QString &appId)
 
     if (d.exists())
         d.removeRecursively();
-
-    populateSizes();
 }
 
 void StorageAbout::clearAppCache(const QString &appId)
@@ -564,8 +562,6 @@ void StorageAbout::clearAppCache(const QString &appId)
 
     if (d.exists())
         d.removeRecursively();
-
-    populateSizes();
 }
 
 void StorageAbout::clearAppConfig(const QString &appId)
@@ -574,8 +570,6 @@ void StorageAbout::clearAppConfig(const QString &appId)
 
     if (d.exists())
         d.removeRecursively();
-
-    populateSizes();
 }
 
 void StorageAbout::uninstallApp(const QString &appId, const QString &version)
@@ -583,8 +577,6 @@ void StorageAbout::uninstallApp(const QString &appId, const QString &version)
     QProcess p;
     p.start("pkcon", QStringList() << "remove" << appId + ";" + version + ";all;local:click", QIODevice::ReadOnly);
     p.waitForFinished();
-
-    populateSizes();
 }
 
 bool StorageAbout::getRefreshing() const
@@ -609,6 +601,7 @@ void StorageAbout::endRefresh()
 
 void StorageAbout::refresh()
 {
+    populateSizes();
     m_clickModel.refresh();
 }
 

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -143,8 +143,15 @@ StorageAbout::StorageAbout(QObject *parent) :
     m_moviesSize(0),
     m_audioSize(0),
     m_picturesSize(0),
+    m_documentsSize(0),
+    m_downloadsSize(0),
     m_otherSize(0),
     m_homeSize(0),
+    m_anboxSize(0),
+    m_libertineSize(0),
+    m_appCacheSize(0),
+    m_appConfigSize(0),
+    m_appDataSize(0),
     m_propertyService(new QDBusInterface(PROPERTY_SERVICE_OBJ,
         PROPERTY_SERVICE_PATH,
         PROPERTY_SERVICE_OBJ,
@@ -296,10 +303,46 @@ quint64 StorageAbout::getPicturesSize()
     return m_picturesSize;
 }
 
+quint64 StorageAbout::getDocumentsSize()
+{
+    return m_documentsSize;
+}
+
+quint64 StorageAbout::getDownloadsSize()
+{
+    return m_downloadsSize;
+}
+
 quint64 StorageAbout::getHomeSize()
 {
     return m_homeSize;
 }
+
+quint64 StorageAbout::getAnboxSize()
+{
+    return m_anboxSize;
+}
+
+quint64 StorageAbout::getLibertineSize()
+{
+    return m_libertineSize;
+}
+
+quint64 StorageAbout::getAppCacheSize()
+{
+    return m_appCacheSize;
+}
+
+quint64 StorageAbout::getAppConfigSize()
+{
+    return m_appConfigSize;
+}
+
+quint64 StorageAbout::getAppDataSize()
+{
+    return m_appDataSize;
+}
+
 
 void StorageAbout::populateSizes()
 {
@@ -327,10 +370,52 @@ void StorageAbout::populateSizes()
                 new MeasureData(running_ptr, this, &m_picturesSize,
                                 m_cancellable));
 
+    measure_special_file(
+                G_USER_DIRECTORY_DOCUMENTS,
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_documentsSize,
+                                m_cancellable));
+
+    measure_special_file(
+                G_USER_DIRECTORY_DOWNLOAD,
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_downloadsSize,
+                                m_cancellable));
+
     measure_file(
                 g_get_home_dir(),
                 measure_finished,
                 new MeasureData(running_ptr, this, &m_homeSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/anbox-data",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_anboxSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.cache/libertine-container",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_libertineSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.cache",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_appCacheSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.config",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_appConfigSize,
+                                m_cancellable));
+
+    measure_file(
+                "/home/phablet/.local/share",
+                measure_finished,
+                new MeasureData(running_ptr, this, &m_appDataSize,
                                 m_cancellable));
 }
 
@@ -352,7 +437,7 @@ void StorageAbout::prepareMountedVolumes()
             /* Only check devices once */
             if (checked.contains(drive))
                 continue;
-             
+
             checked.append(drive);
             QString devicePath(getDevicePath(drive));
             if (devicePath.isEmpty() || m_mountedVolumes.contains(drive))

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -630,6 +630,52 @@ qint64 StorageAbout::getTotalSpace(const QString mount_point)
     return -1;
 }
 
+void StorageAbout::clearAppData(const QString &appId)
+{
+    QDir d(APPDATA_FOLDER + appId);
+
+    if (d.exists())
+        d.removeRecursively();
+
+    populateSizes();
+}
+
+void StorageAbout::clearAppCache(const QString &appId)
+{
+    QDir d(CACHE_FOLDER + appId);
+
+    if (d.exists())
+        d.removeRecursively();
+
+    populateSizes();
+}
+
+void StorageAbout::clearAppConfig(const QString &appId)
+{
+    QDir d(CONFIG_FOLDER + appId);
+
+    if (d.exists())
+        d.removeRecursively();
+
+    populateSizes();
+}
+
+void StorageAbout::uninstallApp(const QString &appId, const QString &version)
+{
+    QProcess p;
+    p.start("pkcon", QStringList() << "remove" << appId + ";" + version + ";all;local:click", QIODevice::ReadOnly);
+    p.waitForFinished();
+
+    populateSizes();
+}
+
+void StorageAbout::refresh()
+{
+    m_clickModel.refresh();
+    m_clickFilterProxy.invalidate();
+    Q_EMIT clickListChanged();
+}
+
 StorageAbout::~StorageAbout() {
     if (m_cancellable) {
         g_cancellable_cancel(m_cancellable);

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -46,6 +46,10 @@
 #include <hybris/properties/properties.h>
 #include <QDBusReply>
 
+#define CACHE_FOLDER "/home/phablet/.cache/"
+#define APPDATA_FOLDER "/home/phablet/.local/share/"
+#define CONFIG_FOLDER "/home/phablet/.config/"
+
 namespace {
     const QString PROPERTY_SERVICE_PATH = "/com/canonical/PropertyService";
     const QString PROPERTY_SERVICE_OBJ = "com.canonical.PropertyService";
@@ -287,6 +291,31 @@ void StorageAbout::setSortRole(ClickModel::Roles newRole)
 quint64 StorageAbout::getClickSize() const
 {
     return m_clickModel.getClickSize();
+}
+
+quint64 StorageAbout::getBiggestAppTotalSize() const
+{
+    return m_clickModel.getBiggestAppTotalSize();
+}
+
+QVariant StorageAbout::getBiggestInstallSize() const
+{
+    return m_clickModel.getBiggestInstallSize();
+}
+
+quint64 StorageAbout::getBiggestConfigSize() const
+{
+    return m_clickModel.getBiggestConfigSize();
+}
+
+quint64 StorageAbout::getBiggestCacheSize() const
+{
+    return m_clickModel.getBiggestCacheSize();
+}
+
+quint64 StorageAbout::getBiggestDataSize() const
+{
+    return m_clickModel.getBiggestDataSize();
 }
 
 quint64 StorageAbout::getMoviesSize()

--- a/plugins/about/storageabout.cpp
+++ b/plugins/about/storageabout.cpp
@@ -277,9 +277,9 @@ void StorageAbout::setSortRole(ClickModel::Roles newRole)
 {
     m_clickFilterProxy.setSortRole(newRole);
 
-    m_clickFilterProxy.sort(0, newRole == ClickModel::InstalledSizeRole ?
-                                Qt::DescendingOrder :
-                                Qt::AscendingOrder);
+    m_clickFilterProxy.sort(0, newRole == ClickModel::DisplayNameRole ?
+                                Qt::AscendingOrder :
+                                Qt::DescendingOrder);
     m_clickFilterProxy.invalidate();
     Q_EMIT(sortRoleChanged());
 }

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -142,6 +142,10 @@ class StorageAbout : public QObject
                READ getDeveloperModeCapable
                 CONSTANT)
 
+    Q_PROPERTY(bool refreshing
+               READ getRefreshing
+               NOTIFY refreshingChanged)
+
 public:
     explicit StorageAbout(QObject *parent = 0);
     ~StorageAbout();
@@ -183,12 +187,19 @@ public:
     Q_INVOKABLE void clearAppCache(const QString &appId);
     Q_INVOKABLE void clearAppConfig(const QString &appId);
     Q_INVOKABLE void uninstallApp(const QString &appId, const QString &version);
-    Q_INVOKABLE void refresh();
+    bool getRefreshing() const;
+    void setRefreshing(const bool refreshing);
+    Q_INVOKABLE void refreshAsync();
+    void refresh();
+
+public Q_SLOTS:
+    void endRefresh();
 
 Q_SIGNALS:
     void sortRoleChanged();
     void sizeReady();
     void clickListChanged();
+    void refreshingChanged();
 
 private:
     void prepareMountedVolumes();
@@ -211,6 +222,8 @@ private:
     quint64 m_appCacheSize;
     quint64 m_appConfigSize;
     quint64 m_appDataSize;
+    bool m_refreshing;
+
 
     QMap<QString, QString> m_mounts;
 

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -52,27 +52,27 @@ class StorageAbout : public QObject
 
     Q_PROPERTY(quint64 totalClickSize
                READ getClickSize
-               CONSTANT)
+               NOTIFY clickListChanged)
 
     Q_PROPERTY(quint64 biggestAppTotalSize
                READ getBiggestAppTotalSize
-               CONSTANT)
+               NOTIFY clickListChanged)
 
     Q_PROPERTY(QVariant biggestInstallSize
                READ getBiggestInstallSize
-               CONSTANT)
+               NOTIFY clickListChanged)
 
     Q_PROPERTY(quint64 biggestConfigSize
                READ getBiggestConfigSize
-               CONSTANT)
+               NOTIFY clickListChanged)
 
     Q_PROPERTY(quint64 biggestCacheSize
                READ getBiggestCacheSize
-               CONSTANT)
+               NOTIFY clickListChanged)
 
     Q_PROPERTY(quint64 biggestDataSize
                READ getBiggestDataSize
-               CONSTANT)
+               NOTIFY clickListChanged)
 
     Q_PROPERTY(QStringList mountedVolumes
                READ getMountedVolumes
@@ -179,10 +179,16 @@ public:
     bool getDeveloperMode();
     void setDeveloperMode(bool newMode);
     bool getDeveloperModeCapable() const;
+    Q_INVOKABLE void clearAppData(const QString &appId);
+    Q_INVOKABLE void clearAppCache(const QString &appId);
+    Q_INVOKABLE void clearAppConfig(const QString &appId);
+    Q_INVOKABLE void uninstallApp(const QString &appId, const QString &version);
+    Q_INVOKABLE void refresh();
 
 Q_SIGNALS:
     void sortRoleChanged();
     void sizeReady();
+    void clickListChanged();
 
 private:
     void prepareMountedVolumes();

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -90,36 +90,8 @@ class StorageAbout : public QObject
                READ getPicturesSize
                NOTIFY sizeReady)
 
-    Q_PROPERTY(quint64 documentsSize
-               READ getDocumentsSize
-               NOTIFY sizeReady)
-
-    Q_PROPERTY(quint64 downloadsSize
-               READ getDownloadsSize
-               NOTIFY sizeReady)
-
     Q_PROPERTY(quint64 homeSize
                READ getHomeSize
-               NOTIFY sizeReady)
-
-    Q_PROPERTY(quint64 anboxSize
-               READ getAnboxSize
-               NOTIFY sizeReady)
-
-    Q_PROPERTY(quint64 libertineSize
-               READ getLibertineSize
-               NOTIFY sizeReady)
-
-    Q_PROPERTY(quint64 appCacheSize
-               READ getAppCacheSize
-               NOTIFY sizeReady)
-
-    Q_PROPERTY(quint64 appConfigSize
-               READ getAppConfigSize
-               NOTIFY sizeReady)
-
-    Q_PROPERTY(quint64 appDataSize
-               READ getAppDataSize
                NOTIFY sizeReady)
 
     Q_PROPERTY(ClickModel::Roles sortRole
@@ -166,14 +138,7 @@ public:
     quint64 getMoviesSize();
     quint64 getAudioSize();
     quint64 getPicturesSize();
-    quint64 getDocumentsSize();
-    quint64 getDownloadsSize();
     quint64 getHomeSize();
-    quint64 getAnboxSize();
-    quint64 getLibertineSize();
-    quint64 getAppCacheSize();
-    quint64 getAppConfigSize();
-    quint64 getAppDataSize();
     Q_INVOKABLE void populateSizes();
     QStringList getMountedVolumes();
     Q_INVOKABLE QString getDevicePath (const QString mount_point) const;
@@ -213,15 +178,8 @@ private:
     quint64 m_moviesSize;
     quint64 m_audioSize;
     quint64 m_picturesSize;
-    quint64 m_documentsSize;
-    quint64 m_downloadsSize;
     quint64 m_otherSize;
     quint64 m_homeSize;
-    quint64 m_anboxSize;
-    quint64 m_libertineSize;
-    quint64 m_appCacheSize;
-    quint64 m_appConfigSize;
-    quint64 m_appDataSize;
     bool m_refreshing;
     QFutureWatcher<void> m_refreshWatcher;
 

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -70,8 +70,36 @@ class StorageAbout : public QObject
                READ getPicturesSize
                NOTIFY sizeReady)
 
+    Q_PROPERTY(quint64 documentsSize
+               READ getDocumentsSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 downloadsSize
+               READ getDownloadsSize
+               NOTIFY sizeReady)
+
     Q_PROPERTY(quint64 homeSize
                READ getHomeSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 anboxSize
+               READ getAnboxSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 libertineSize
+               READ getLibertineSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 appCacheSize
+               READ getAppCacheSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 appConfigSize
+               READ getAppConfigSize
+               NOTIFY sizeReady)
+
+    Q_PROPERTY(quint64 appDataSize
+               READ getAppDataSize
                NOTIFY sizeReady)
 
     Q_PROPERTY(ClickModel::Roles sortRole
@@ -109,7 +137,14 @@ public:
     quint64 getMoviesSize();
     quint64 getAudioSize();
     quint64 getPicturesSize();
+    quint64 getDocumentsSize();
+    quint64 getDownloadsSize();
     quint64 getHomeSize();
+    quint64 getAnboxSize();
+    quint64 getLibertineSize();
+    quint64 getAppCacheSize();
+    quint64 getAppConfigSize();
+    quint64 getAppDataSize();
     Q_INVOKABLE void populateSizes();
     QStringList getMountedVolumes();
     Q_INVOKABLE QString getDevicePath (const QString mount_point) const;
@@ -136,8 +171,15 @@ private:
     quint64 m_moviesSize;
     quint64 m_audioSize;
     quint64 m_picturesSize;
+    quint64 m_documentsSize;
+    quint64 m_downloadsSize;
     quint64 m_otherSize;
     quint64 m_homeSize;
+    quint64 m_anboxSize;
+    quint64 m_libertineSize;
+    quint64 m_appCacheSize;
+    quint64 m_appConfigSize;
+    quint64 m_appDataSize;
 
     QMap<QString, QString> m_mounts;
 

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -30,7 +30,7 @@
 #include <QProcess>
 #include <QVariant>
 #include <QDBusInterface>
-
+#include <QFutureWatcher>
 
 class StorageAbout : public QObject
 {
@@ -190,7 +190,6 @@ public:
     bool getRefreshing() const;
     void setRefreshing(const bool refreshing);
     Q_INVOKABLE void refreshAsync();
-    void refresh();
 
 public Q_SLOTS:
     void endRefresh();
@@ -203,6 +202,7 @@ Q_SIGNALS:
 
 private:
     void prepareMountedVolumes();
+    void refresh();
     QStringList m_mountedVolumes;
     QString m_serialNumber;
     QString m_vendorString;
@@ -223,6 +223,7 @@ private:
     quint64 m_appConfigSize;
     quint64 m_appDataSize;
     bool m_refreshing;
+    QFutureWatcher<void> m_refreshWatcher;
 
 
     QMap<QString, QString> m_mounts;

--- a/plugins/about/storageabout.h
+++ b/plugins/about/storageabout.h
@@ -54,6 +54,26 @@ class StorageAbout : public QObject
                READ getClickSize
                CONSTANT)
 
+    Q_PROPERTY(quint64 biggestAppTotalSize
+               READ getBiggestAppTotalSize
+               CONSTANT)
+
+    Q_PROPERTY(QVariant biggestInstallSize
+               READ getBiggestInstallSize
+               CONSTANT)
+
+    Q_PROPERTY(quint64 biggestConfigSize
+               READ getBiggestConfigSize
+               CONSTANT)
+
+    Q_PROPERTY(quint64 biggestCacheSize
+               READ getBiggestCacheSize
+               CONSTANT)
+
+    Q_PROPERTY(quint64 biggestDataSize
+               READ getBiggestDataSize
+               CONSTANT)
+
     Q_PROPERTY(QStringList mountedVolumes
                READ getMountedVolumes
                CONSTANT)
@@ -134,6 +154,11 @@ public:
     ClickModel::Roles getSortRole();
     void setSortRole(ClickModel::Roles newRole);
     quint64 getClickSize() const;
+    quint64 getBiggestAppTotalSize() const;
+    QVariant getBiggestInstallSize() const;
+    quint64 getBiggestConfigSize() const;
+    quint64 getBiggestCacheSize() const;
+    quint64 getBiggestDataSize() const;
     quint64 getMoviesSize();
     quint64 getAudioSize();
     quint64 getPicturesSize();

--- a/schema/com.ubuntu.touch.system-settings.gschema.xml
+++ b/schema/com.ubuntu.touch.system-settings.gschema.xml
@@ -8,6 +8,14 @@
         <value nick="passcode" value="2" />
         <value nick="password" value="3" />
     </enum>
+    <enum id="storage-sort-value">
+        <value nick="name" value="1" />
+        <value nick="total-size" value="2" />
+        <value nick="installed-size" value="3" />
+        <value nick="cache-size" value="4" />
+        <value nick="data-size" value="5" />
+        <value nick="config-size" value="6" />
+    </enum>
     <schema id="com.ubuntu.touch.system-settings" path="/com/ubuntu/touch/system-settings/">
         <key name="background-duplicate" type="b">
             <default>true</default>
@@ -22,10 +30,9 @@
             <default>""</default>
             <description>When background-duplicate is 'true', the value to restore the least recently changed screen to.</description>
         </key>
-        <key name="storage-sort-by-name" type="b">
-            <default>true</default>
-            <summary>Whether the applications should be sorted by name.</summary>
-            <description>If true the applications are sorted by name, otherwise by disk size.</description>
+        <key name="storage-sort" enum="storage-sort-value">
+            <default>"total-size"</default>
+            <summary>Choose the value applications should be sorted by.</summary>
         </key>
         <key name="callforwarding-summaries" type="a{ss}">
             <summary>Call forwarding summaries</summary>


### PR DESCRIPTION
1. Add the possibility to uninstall an app as well as clean cache, config or data.
2. Chance to bulk clean cache, config or data for selected apps (press and hold)
3. More sorting option
4. Pull to refresh

More info and screenshot in the [forum thread](https://forums.ubports.com/topic/5070/improve-system-settings-disk-usage-analyzer)

If you think the qml file got to big I can move out the app's delegate and/or the dialogs