### PR TITLE
Fix reference to root variable

### DIFF
--- a/plugins/security-privacy/PageComponent.qml
+++ b/plugins/security-privacy/PageComponent.qml
@@ -116,7 +116,7 @@ ItemPage {
 
     GSettings {
         id: powerSettings
-        schema.id: usePowerd ? "com.ubuntu.touch.system" : "org.gnome.desktop.session"
+        schema.id: root.usePowerd ? "com.ubuntu.touch.system" : "org.gnome.desktop.session"
     }
 
     Flickable {


### PR DESCRIPTION
This was causing the wrong scheme to get loaded, resulting in the value
for activityTimeout being undefined, and "After nan minutes" being displayed
in the privacy lock timeout settings page.