### PR TITLE
change ubuntu icon to info icon

### DIFF
--- a/plugins/about/about.settings
+++ b/plugins/about/about.settings
@@ -1,5 +1,5 @@
 {
-    "icon": "ubuntu-logo-symbolic",
+    "icon": "info",
     "name": "About",
     "translations": "ubuntu-system-settings",
     "category": "uncategorized-bottom",


### PR DESCRIPTION
In favor of a more generic about page, change ubuntu icon to "info" icon