### PR TITLE
d/control: remove from B-Ds: libunity-api-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Build-Depends:
  libqtdbustest1-dev <!nocheck>,
  libtrust-store-dev,
  libudev-dev,
- libunity-api-dev,
  libupower-glib-dev,
  pep8 <!nocheck>,
  pkg-config,


### PR DESCRIPTION
Seems to be a left-over from when the wizard was still in this repo. No
longer used.